### PR TITLE
Add recovery action for failure-blocked tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MAAS is a board-first multi-agent operating system. This repository now contains
 - a lightweight supervisor/lifecycle foundation
 - task-scoped capability grants for execution, heartbeats, activity, artifacts, and session completion
 - failure-memory logging with repeated-failure alerting and dashboard visibility
+- operator recovery for failure-blocked tasks
 - concrete simulated runtime adapters for Python Script, Claude Code, and OpenAI Codex
 - a React control room with operator actions for supervisor runs and idle-agent assignment
 - board-side operator controls for review, reprioritize, reassign, pause/resume, and halt
@@ -61,6 +62,7 @@ The project bootstrap creates:
 - `POST /api/tasks/actions/refresh-ready`
 - `POST /api/tasks/actions/allocate-ready`
 - `POST /api/tasks/{task_id}/actions/evaluate`
+- `POST /api/tasks/{task_id}/actions/recover`
 - `POST /api/agents/{agent_id}/actions/assign-next`
 - `POST /api/supervisor/run`
 
@@ -72,6 +74,7 @@ The primary operational surface is the Kanban board returned by `/api/board`.
 - `maas task allocate --project-root .`
 - `maas task allocate --project-root . --agent-id <agent_id>`
 - `maas task evaluate --project-root . --task-id <task_id>`
+- `maas task recover --project-root . --task-id <task_id> --actor-id <agent_id>`
 - `maas supervisor --project-root . --once`
 - `maas failure list --project-root .`
 - `maas escalation list --project-root .`
@@ -89,6 +92,7 @@ These commands expose the current dependency-aware ready queue, allocator flow, 
 - board cards and the task capabilities API expose the currently active task grants
 - risky task and agent interventions can now be routed through an escalation queue instead of being executed immediately
 - failed and timed-out sessions are now recorded in failure memory and can raise repeated-failure alerts
+- operators can return failure-blocked tasks to the planning queue without resuming the old execution context
 
 ## Provider Notes
 

--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -19,7 +19,15 @@ from maas.services.live import build_live_snapshot, sse_stream
 from maas.services.provider_runtime import list_provider_runtime_status, run_provider_task
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 from maas.services.security import fetch_task_capabilities
-from maas.services.steering import halt_task, pause_agent, reassign_task, reprioritize_task, resume_agent, review_task
+from maas.services.steering import (
+    halt_task,
+    pause_agent,
+    reassign_task,
+    recover_task,
+    reprioritize_task,
+    resume_agent,
+    review_task,
+)
 from maas.supervisor import run_supervisor_once
 
 
@@ -442,6 +450,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return halt_task(connection, task_id, payload.actor_id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/tasks/{task_id}/actions/recover")
+    def task_recover_action(task_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return recover_task(connection, task_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -15,6 +15,7 @@ from maas.services.failure_memory import fetch_failure_log
 from maas.services.provider_runtime import run_provider_task
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
+from maas.services.steering import recover_task
 from maas.supervisor import run_supervisor_once
 
 
@@ -56,6 +57,11 @@ def build_parser():
     task_evaluate_parser = task_subparsers.add_parser("evaluate")
     task_evaluate_parser.add_argument("--project-root", default=".")
     task_evaluate_parser.add_argument("--task-id", required=True)
+
+    task_recover_parser = task_subparsers.add_parser("recover")
+    task_recover_parser.add_argument("--project-root", default=".")
+    task_recover_parser.add_argument("--task-id", required=True)
+    task_recover_parser.add_argument("--actor-id", required=True)
 
     task_allocate_parser = task_subparsers.add_parser("allocate")
     task_allocate_parser.add_argument("--project-root", default=".")
@@ -213,6 +219,8 @@ def command_task(args):
             print(json.dumps({"changed": changed, "tasks": resolve_ready_tasks(connection)}, indent=2))
         elif args.task_command == "evaluate":
             print(json.dumps(evaluate_task(connection, paths, args.task_id), indent=2))
+        elif args.task_command == "recover":
+            print(json.dumps(recover_task(connection, args.task_id, args.actor_id), indent=2))
         elif args.task_command == "allocate":
             if args.agent_id:
                 print(json.dumps(assign_next_task(connection, args.agent_id, actor_id=args.actor_id), indent=2))

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -10,6 +10,8 @@ from maas.services.security import (
     revoke_task_capabilities,
 )
 
+RECOVERABLE_FAILURE_REVIEW_STATES = ("session_failed", "stale_session")
+
 
 def _audit(connection, project_id, actor_id, action_type, resource_type, resource_id, detail):
     connection.execute(
@@ -166,6 +168,71 @@ def halt_task(connection, task_id, actor_id):
     )
     connection.commit()
     return {"task_id": task_id, "status": "cancelled"}
+
+
+def recover_task(connection, task_id, actor_id):
+    task = connection.execute(
+        """
+        SELECT task_id, project_id, assigned_agent_id, status, review_state
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        raise ValueError("Task not found")
+    ensure_board_action_allowed(connection, actor_id, task["project_id"], "recover_task", "task", task_id)
+    if task["status"] != "blocked":
+        raise ValueError("Only blocked tasks can be recovered")
+    if task["review_state"] not in RECOVERABLE_FAILURE_REVIEW_STATES:
+        raise ValueError("Task is not blocked by a recoverable failure")
+
+    if task["assigned_agent_id"]:
+        revoke_task_capabilities(
+            connection,
+            task["project_id"],
+            task_id,
+            agent_id=task["assigned_agent_id"],
+            reason="task_recovered",
+            revoked_by=actor_id,
+        )
+
+    connection.execute(
+        """
+        UPDATE tasks
+        SET status = 'planned',
+            assigned_agent_id = NULL,
+            progress_pct = 0,
+            review_state = NULL,
+            last_heartbeat_at = NULL,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    )
+    _audit(
+        connection,
+        task["project_id"],
+        actor_id,
+        "recover_task",
+        "task",
+        task_id,
+        {
+            "previous_status": task["status"],
+            "previous_review_state": task["review_state"],
+            "previous_agent_id": task["assigned_agent_id"],
+        },
+    )
+    _activity(
+        connection,
+        task["project_id"],
+        task["assigned_agent_id"],
+        task_id,
+        "recovered",
+        "Task returned to the planning queue after failure recovery.",
+    )
+    connection.commit()
+    return {"task_id": task_id, "status": "planned"}
 
 
 def reprioritize_task(connection, task_id, actor_id, priority):

--- a/tests/test_api_board_actions.py
+++ b/tests/test_api_board_actions.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from maas.api import create_app
 from maas.db import connect, project_paths
 from maas.services.bootstrap import bootstrap_project
+from maas.services.lifecycle import end_session, start_session
 
 
 class BoardApiActionsTest(unittest.TestCase):
@@ -178,6 +179,82 @@ class BoardApiActionsTest(unittest.TestCase):
             self.assertEqual(halted_card["status"], "cancelled")
             self.assertEqual(halted_card["review_state"], "halted_by_operator")
             self.assertEqual(halted_card["capabilities"], [])
+
+    def test_recover_failed_task_returns_it_to_planned_queue(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(tmpdir, name="Recover Task Test", description="Recover failure-blocked task", project_type="custom")
+            connection = connect(result["paths"])
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Wire the scheduler and board read model'"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting recovery test",
+                )
+                end_session(connection, session_id, "failed", "Recoverable failure")
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recover_response = client.post(
+                "/api/tasks/{0}/actions/recover".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(recover_response.status_code, 200)
+            self.assertEqual(recover_response.json()["status"], "planned")
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                recovered_task = connection.execute(
+                    """
+                    SELECT status, assigned_agent_id, review_state, progress_pct, last_heartbeat_at
+                    FROM tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+            finally:
+                connection.close()
+
+            capabilities_response = client.get("/api/tasks/{0}/capabilities".format(task_id))
+            self.assertEqual(capabilities_response.status_code, 200)
+            self.assertEqual(recovered_task["status"], "planned")
+            self.assertIsNone(recovered_task["assigned_agent_id"])
+            self.assertIsNone(recovered_task["review_state"])
+            self.assertEqual(recovered_task["progress_pct"], 0)
+            self.assertIsNone(recovered_task["last_heartbeat_at"])
+            self.assertEqual(capabilities_response.json()["grants"], [])
+
+    def test_recover_rejects_non_failure_blocked_tasks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Recover Guard Test", description="Reject invalid recover path", project_type="custom")
+            client = TestClient(create_app(tmpdir))
+
+            pause_response = client.post(
+                "/api/agents/agent_builder/actions/pause",
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(pause_response.status_code, 200)
+
+            blocked_task = client.get("/api/board", params={"search": "Implement FastAPI board endpoint"}).json()
+            task_id = [
+                task
+                for column in blocked_task["columns"]
+                for task in column["tasks"]
+                if task["title"] == "Implement FastAPI board endpoint"
+            ][0]["task_id"]
+
+            recover_response = client.post(
+                "/api/tasks/{0}/actions/recover".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(recover_response.status_code, 400)
 
     def test_halt_preserves_paused_agent_state(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_supervisor_api.py
+++ b/tests/test_supervisor_api.py
@@ -85,6 +85,57 @@ class SupervisorApiTest(unittest.TestCase):
             self.assertIsNone(agent["current_task_id"])
             self.assertEqual(failure["failure_type"], "session_timed_out")
 
+    def test_recover_action_can_requeue_stale_session_task_without_resetting_agent_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Supervisor Recover Test",
+                description="Recover stale-session task",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Implement FastAPI board endpoint'"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    UPDATE sessions
+                    SET last_heartbeat_at = '2000-01-01 00:00:00'
+                    WHERE task_id = ? AND status = 'active'
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+                run_supervisor_once(connection, stale_after_seconds=90, allocate_limit=0)
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recover_response = client.post(
+                "/api/tasks/{0}/actions/recover".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(recover_response.status_code, 200)
+
+            connection = connect(result["paths"])
+            try:
+                task = connection.execute(
+                    "SELECT status, assigned_agent_id, review_state FROM tasks WHERE task_id = ?",
+                    (task_id,),
+                ).fetchone()
+                agent = connection.execute(
+                    "SELECT status, current_task_id FROM agents WHERE agent_id = 'agent_builder'"
+                ).fetchone()
+            finally:
+                connection.close()
+
+            self.assertEqual(task["status"], "planned")
+            self.assertIsNone(task["assigned_agent_id"])
+            self.assertIsNone(task["review_state"])
+            self.assertEqual(agent["status"], "error")
+            self.assertIsNone(agent["current_task_id"])
+
     def test_supervisor_api_endpoint_runs_pass(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Supervisor API Test", description="Supervisor API test", project_type="custom")

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -10,6 +10,7 @@ interface BoardColumnProps {
   onPriorityChange?: (taskId: string, priority: number) => void;
   onReassign?: (taskId: string, agentId: string) => void;
   onHalt?: (taskId: string) => void;
+  onRecover?: (taskId: string) => void;
 }
 
 export function BoardColumn({
@@ -20,7 +21,8 @@ export function BoardColumn({
   onAgentAction,
   onPriorityChange,
   onReassign,
-  onHalt
+  onHalt,
+  onRecover
 }: BoardColumnProps) {
   return (
     <section className="board-column">
@@ -43,6 +45,7 @@ export function BoardColumn({
             onPriorityChange={onPriorityChange}
             onReassign={onReassign}
             onHalt={onHalt}
+            onRecover={onRecover}
           />
         ))}
       </div>

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,5 +1,7 @@
 import type { BoardTask, FilterOption } from "../types";
 
+const RECOVERABLE_REVIEW_STATES = new Set(["session_failed", "stale_session"]);
+
 function formatPriority(priority: number) {
   if (priority >= 90) {
     return "Critical";
@@ -45,6 +47,7 @@ interface TaskCardProps {
   onPriorityChange?: (taskId: string, priority: number) => void;
   onReassign?: (taskId: string, agentId: string) => void;
   onHalt?: (taskId: string) => void;
+  onRecover?: (taskId: string) => void;
 }
 
 export function TaskCard({
@@ -55,7 +58,8 @@ export function TaskCard({
   onAgentAction,
   onPriorityChange,
   onReassign,
-  onHalt
+  onHalt,
+  onRecover
 }: TaskCardProps) {
   const reviewApproveKey = `review:${task.task_id}:approve`;
   const reviewRejectKey = `review:${task.task_id}:reject`;
@@ -63,18 +67,22 @@ export function TaskCard({
   const reprioritizeKey = `reprioritize:${task.task_id}`;
   const reassignKey = `reassign:${task.task_id}`;
   const haltKey = `halt:${task.task_id}`;
+  const recoverKey = `recover:${task.task_id}`;
   const isPendingReviewApprove = pendingActionKey === reviewApproveKey;
   const isPendingReviewReject = pendingActionKey === reviewRejectKey;
   const isPendingAgentAction = pendingActionKey === agentActionKey;
   const isPendingReprioritize = pendingActionKey === reprioritizeKey;
   const isPendingReassign = pendingActionKey === reassignKey;
   const isPendingHalt = pendingActionKey === haltKey;
+  const isPendingRecover = pendingActionKey === recoverKey;
   const canReview = task.status === "review" && !!onReviewAction;
   const canToggleAgent = !!task.agent?.id && !!onAgentAction && (task.agent?.status === "running" || task.agent?.status === "paused");
   const canSteerTask = task.status !== "done" && task.status !== "cancelled";
   const canReassign = canSteerTask && task.status !== "in_progress" && !!onReassign && agentOptions.length > 0;
   const canReprioritize = canSteerTask && !!onPriorityChange;
   const canHalt = canSteerTask && !!onHalt;
+  const canRecover =
+    task.status === "blocked" && !!onRecover && RECOVERABLE_REVIEW_STATES.has(task.review_state ?? "");
 
   return (
     <article className={`task-card task-card--${task.status}`}>
@@ -113,7 +121,7 @@ export function TaskCard({
           <dd>{task.failure_count ? `${task.failure_count} logged` : "None"}</dd>
         </div>
       </dl>
-      {(canReview || canToggleAgent || canReassign || canReprioritize || canHalt) && (
+      {(canReview || canToggleAgent || canReassign || canReprioritize || canHalt || canRecover) && (
         <div className="task-card__actions">
           {canReview && (
             <>
@@ -196,6 +204,16 @@ export function TaskCard({
               onClick={() => onHalt?.(task.task_id)}
             >
               {isPendingHalt ? "Halting..." : "Halt task"}
+            </button>
+          )}
+          {canRecover && (
+            <button
+              type="button"
+              className="task-action task-action--approve"
+              disabled={isPendingRecover}
+              onClick={() => onRecover?.(task.task_id)}
+            >
+              {isPendingRecover ? "Recovering..." : "Recover task"}
             </button>
           )}
         </div>

--- a/web/src/lib/boardApi.ts
+++ b/web/src/lib/boardApi.ts
@@ -308,3 +308,9 @@ export async function haltTask(taskId: string) {
     actor_id: DEFAULT_ACTOR_ID
   });
 }
+
+export async function recoverTask(taskId: string) {
+  await postJson(`/api/tasks/${taskId}/actions/recover`, {
+    actor_id: DEFAULT_ACTOR_ID
+  });
+}

--- a/web/src/pages/BoardPage.tsx
+++ b/web/src/pages/BoardPage.tsx
@@ -1,5 +1,13 @@
 import { startTransition, useDeferredValue, useEffect, useMemo, useState } from "react";
-import { fetchBoard, haltTask, reassignTask, reprioritizeTask, reviewTask, setAgentState } from "../lib/boardApi";
+import {
+  fetchBoard,
+  haltTask,
+  reassignTask,
+  recoverTask,
+  reprioritizeTask,
+  reviewTask,
+  setAgentState
+} from "../lib/boardApi";
 import { useLivePulse } from "../lib/useLivePulse";
 import type { BoardFiltersInput, BoardResponse, FilterOption } from "../types";
 import { BoardColumn } from "../components/BoardColumn";
@@ -164,6 +172,21 @@ export function BoardPage() {
     }
   }
 
+  async function handleRecover(taskId: string) {
+    const actionKey = `recover:${taskId}`;
+    setPendingActionKey(actionKey);
+    setNotice(null);
+    try {
+      await recoverTask(taskId);
+      setNotice(`Task ${taskId} returned to the planning queue.`);
+      await loadBoard();
+    } catch {
+      setNotice("Task recovery failed; keep the current board snapshot under review.");
+    } finally {
+      setPendingActionKey(null);
+    }
+  }
+
   return (
     <main className="board-shell">
       <section className="hero-panel">
@@ -280,6 +303,7 @@ export function BoardPage() {
             onPriorityChange={handlePriorityChange}
             onReassign={handleReassign}
             onHalt={handleHalt}
+            onRecover={handleRecover}
           />
         ))}
       </section>


### PR DESCRIPTION
## Summary
- add a board/API/CLI recovery action for tasks blocked by failed or stale sessions
- clear stale assignment context and task capabilities when operators requeue failure-blocked work
- expose the recovery control in the board UI and cover failed-session and stale-session recovery paths with tests

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_api_board_actions
- PYTHONPATH=src python3 -m unittest tests.test_supervisor_api
- PYTHONPATH=src python3 -m py_compile src/maas/services/steering.py src/maas/api.py src/maas/cli.py
- git diff --check

## Notes
- frontend build was not run because this checkout does not have tsc installed locally