### PR TITLE
Resolve incident alerts during recovery

### DIFF
--- a/src/maas/services/alerts.py
+++ b/src/maas/services/alerts.py
@@ -6,6 +6,116 @@ from maas.ids import generate_id
 from maas.services.security import ensure_board_action_allowed
 
 
+def _escape_like(value):
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _record_alert_status_change(connection, project_id, actor_id, alert_id, status, reason=None):
+    connection.execute(
+        """
+        INSERT INTO audit_trail (
+            audit_id, project_id, actor_id, action_type, resource_type, resource_id, detail_json
+        ) VALUES (?, ?, ?, ?, 'alert', ?, ?)
+        """,
+        (
+            generate_id("audit"),
+            project_id,
+            actor_id,
+            "alert_status_updated",
+            alert_id,
+            json.dumps({"status": status, "reason": reason}),
+        ),
+    )
+
+
+def _log_alert_resolution_activity(connection, project_id, actor_id, task_id, action, description, details):
+    connection.execute(
+        """
+        INSERT INTO activity_log (
+            activity_id, project_id, agent_id, task_id, action, category, description, details_json, severity
+        ) VALUES (?, ?, ?, ?, ?, 'steering', ?, ?, 'info')
+        """,
+        (
+            generate_id("act"),
+            project_id,
+            actor_id,
+            task_id,
+            action,
+            description,
+            json.dumps(details),
+        ),
+    )
+
+
+def _resolve_alerts_by_query(connection, query, params, project_id, actor_id, reason, task_id, activity_action, activity_description):
+    rows = connection.execute(query, params).fetchall()
+    resolved_alert_ids = []
+    for row in rows:
+        connection.execute(
+            "UPDATE alerts SET status = 'resolved' WHERE alert_id = ?",
+            (row["alert_id"],),
+        )
+        _record_alert_status_change(connection, project_id, actor_id, row["alert_id"], "resolved", reason=reason)
+        resolved_alert_ids.append(row["alert_id"])
+
+    if resolved_alert_ids:
+        _log_alert_resolution_activity(
+            connection,
+            project_id,
+            actor_id,
+            task_id,
+            activity_action,
+            activity_description,
+            {"alert_ids": resolved_alert_ids, "reason": reason},
+        )
+
+    return resolved_alert_ids
+
+
+def resolve_task_session_failed_alerts(connection, project_id, task_id, actor_id, reason):
+    return _resolve_alerts_by_query(
+        connection,
+        """
+        SELECT alert_id
+        FROM alerts
+        WHERE project_id = ?
+          AND status IN ('open', 'acknowledged')
+          AND title = 'Task session failed'
+          AND description LIKE ?
+          ESCAPE '\\'
+        """,
+        (project_id, "Task {0} failed in session %".format(_escape_like(task_id))),
+        project_id,
+        actor_id,
+        reason,
+        task_id,
+        "task_failure_alert_resolved",
+        "Task failure alerts resolved after task recovery.",
+    )
+
+
+def resolve_stale_heartbeat_alerts(connection, project_id, agent_id, actor_id, reason):
+    return _resolve_alerts_by_query(
+        connection,
+        """
+        SELECT alert_id
+        FROM alerts
+        WHERE project_id = ?
+          AND status IN ('open', 'acknowledged')
+          AND title = 'Stale agent heartbeat'
+          AND description LIKE ?
+          ESCAPE '\\'
+        """,
+        (project_id, "Agent {0} stopped heartbeating for task %".format(_escape_like(agent_id))),
+        project_id,
+        actor_id,
+        reason,
+        None,
+        "stale_heartbeat_alert_resolved",
+        "Stale heartbeat alerts resolved after agent recovery.",
+    )
+
+
 def fetch_alerts(connection):
     rows = connection.execute(
         """
@@ -61,21 +171,7 @@ def update_alert_status(connection, alert_id, actor_id, status):
         "UPDATE alerts SET status = ? WHERE alert_id = ?",
         (status, alert_id),
     )
-    connection.execute(
-        """
-        INSERT INTO audit_trail (
-            audit_id, project_id, actor_id, action_type, resource_type, resource_id, detail_json
-        ) VALUES (?, ?, ?, ?, 'alert', ?, ?)
-        """,
-        (
-            generate_id("audit"),
-            alert["project_id"],
-            actor_id,
-            "alert_status_updated",
-            alert_id,
-            json.dumps({"status": status}),
-        ),
-    )
+    _record_alert_status_change(connection, alert["project_id"], actor_id, alert_id, status)
     connection.execute(
         """
         INSERT INTO activity_log (

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -3,6 +3,7 @@
 import json
 
 from maas.ids import generate_id
+from maas.services.alerts import resolve_stale_heartbeat_alerts, resolve_task_session_failed_alerts
 from maas.services.failure_memory import resolve_repeated_failure_alerts
 from maas.services.security import (
     TASK_EXECUTION_CAPABILITIES,
@@ -238,6 +239,13 @@ def recover_task(connection, task_id, actor_id):
         task_id,
         actor_id,
         resolution_reason="task_recovered",
+    )
+    resolve_task_session_failed_alerts(
+        connection,
+        task["project_id"],
+        task_id,
+        actor_id,
+        reason="task_recovered",
     )
     connection.commit()
     return {"task_id": task_id, "status": "planned"}
@@ -486,6 +494,13 @@ def recover_agent(connection, agent_id, actor_id):
         None,
         "agent_recovered",
         "Agent recovered from error state.",
+    )
+    resolve_stale_heartbeat_alerts(
+        connection,
+        agent["project_id"],
+        agent_id,
+        actor_id,
+        reason="agent_recovered",
     )
     connection.commit()
     return {"agent_id": agent_id, "status": "idle"}

--- a/tests/test_api_board_actions.py
+++ b/tests/test_api_board_actions.py
@@ -219,6 +219,15 @@ class BoardApiActionsTest(unittest.TestCase):
                     """,
                     (task_id,),
                 ).fetchone()
+                session_failed_alert = connection.execute(
+                    """
+                    SELECT status
+                    FROM alerts
+                    WHERE title = 'Task session failed'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
             finally:
                 connection.close()
 
@@ -230,6 +239,7 @@ class BoardApiActionsTest(unittest.TestCase):
             self.assertEqual(recovered_task["progress_pct"], 0)
             self.assertIsNone(recovered_task["last_heartbeat_at"])
             self.assertEqual(capabilities_response.json()["grants"], [])
+            self.assertEqual(session_failed_alert["status"], "resolved")
 
     def test_recover_rejects_non_failure_blocked_tasks(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_supervisor_api.py
+++ b/tests/test_supervisor_api.py
@@ -171,11 +171,21 @@ class SupervisorApiTest(unittest.TestCase):
                 agent = connection.execute(
                     "SELECT status, current_task_id FROM agents WHERE agent_id = 'agent_builder'"
                 ).fetchone()
+                stale_alert = connection.execute(
+                    """
+                    SELECT status
+                    FROM alerts
+                    WHERE title = 'Stale agent heartbeat'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
             finally:
                 connection.close()
 
             self.assertEqual(agent["status"], "idle")
             self.assertIsNone(agent["current_task_id"])
+            self.assertEqual(stale_alert["status"], "resolved")
 
     def test_agent_recover_rejects_non_error_agents(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Status

### Done on main
- [x] Greenfield bootstrap and board-first control room foundation
- [x] Steering controls, permission gating, and escalation queue
- [x] Failure logging, repeated-failure alerts, task recovery, and agent recovery

### Working in this PR
- [x] Resolve task-session-failed alerts when an operator recovers the blocked task
- [x] Resolve stale-heartbeat alerts when an operator recovers the stranded agent
- [x] Cover the new recovery-alert behavior with focused task and supervisor tests

### Still to do after this PR
- [ ] Automated restart, retry, and DLQ workflows
- [ ] Real external provider integrations
- [ ] Brownfield onboarding and multi-project support

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_api_board_actions
- PYTHONPATH=src python3 -m unittest tests.test_supervisor_api
- PYTHONPATH=src python3 -m py_compile src/maas/services/alerts.py src/maas/services/steering.py
- git diff --check