### PR TITLE
Add repeated-failure triage actions

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -25,6 +25,7 @@ from maas.services.steering import (
     reassign_task,
     recover_agent,
     recover_task,
+    resolve_task_repeated_failures,
     reprioritize_task,
     resume_agent,
     review_task,
@@ -463,6 +464,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return recover_task(connection, task_id, payload.actor_id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/tasks/{task_id}/actions/resolve-repeated-failures")
+    def task_resolve_repeated_failures_action(task_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return resolve_task_repeated_failures(connection, task_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -15,7 +15,7 @@ from maas.services.failure_memory import fetch_failure_log
 from maas.services.provider_runtime import run_provider_task
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
-from maas.services.steering import recover_agent, recover_task
+from maas.services.steering import recover_agent, recover_task, resolve_task_repeated_failures
 from maas.supervisor import run_supervisor_once
 
 
@@ -70,6 +70,11 @@ def build_parser():
     task_recover_parser.add_argument("--project-root", default=".")
     task_recover_parser.add_argument("--task-id", required=True)
     task_recover_parser.add_argument("--actor-id", required=True)
+
+    task_resolve_repeated_failures_parser = task_subparsers.add_parser("resolve-repeated-failures")
+    task_resolve_repeated_failures_parser.add_argument("--project-root", default=".")
+    task_resolve_repeated_failures_parser.add_argument("--task-id", required=True)
+    task_resolve_repeated_failures_parser.add_argument("--actor-id", required=True)
 
     task_allocate_parser = task_subparsers.add_parser("allocate")
     task_allocate_parser.add_argument("--project-root", default=".")
@@ -229,6 +234,8 @@ def command_task(args):
             print(json.dumps(evaluate_task(connection, paths, args.task_id), indent=2))
         elif args.task_command == "recover":
             print(json.dumps(recover_task(connection, args.task_id, args.actor_id), indent=2))
+        elif args.task_command == "resolve-repeated-failures":
+            print(json.dumps(resolve_task_repeated_failures(connection, args.task_id, args.actor_id), indent=2))
         elif args.task_command == "allocate":
             if args.agent_id:
                 print(json.dumps(assign_next_task(connection, args.agent_id, actor_id=args.actor_id), indent=2))

--- a/src/maas/services/alerts.py
+++ b/src/maas/services/alerts.py
@@ -33,6 +33,18 @@ def _can_recover_task(connection, task_id):
     return task["status"] == "blocked" and task["review_state"] in RECOVERABLE_FAILURE_REVIEW_STATES
 
 
+def _can_resolve_repeated_failures(connection, task_id):
+    task = connection.execute(
+        """
+        SELECT task_id
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    return task is not None
+
+
 def _can_recover_agent(connection, agent_id):
     agent = connection.execute(
         """
@@ -70,10 +82,10 @@ def _infer_operator_action(connection, title, description):
             }
     if title == "Repeated task failures":
         match = REPEATED_TASK_FAILURE_PATTERN.match(description)
-        if match is not None and _can_recover_task(connection, match.group("task_id")):
+        if match is not None and _can_resolve_repeated_failures(connection, match.group("task_id")):
             return {
-                "action": "recover_task",
-                "label": "Recover task",
+                "action": "resolve_repeated_failures",
+                "label": "Resolve repeated failures",
                 "resource_type": "task",
                 "resource_id": match.group("task_id"),
             }

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -251,6 +251,45 @@ def recover_task(connection, task_id, actor_id):
     return {"task_id": task_id, "status": "planned"}
 
 
+def resolve_task_repeated_failures(connection, task_id, actor_id):
+    task = connection.execute(
+        """
+        SELECT task_id, project_id, status
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        raise ValueError("Task not found")
+    ensure_board_action_allowed(
+        connection,
+        actor_id,
+        task["project_id"],
+        "resolve_task_repeated_failures",
+        "task",
+        task_id,
+    )
+
+    resolved_alert_ids = resolve_repeated_failure_alerts(
+        connection,
+        task["project_id"],
+        task_id,
+        actor_id,
+        resolution_reason="operator_triaged",
+    )
+    if not resolved_alert_ids:
+        raise ValueError("Task has no open repeated-failure alert")
+
+    connection.commit()
+    return {
+        "task_id": task_id,
+        "resolved_alert_ids": resolved_alert_ids,
+        "resolved_count": len(resolved_alert_ids),
+        "status": task["status"],
+    }
+
+
 def reprioritize_task(connection, task_id, actor_id, priority):
     task = connection.execute(
         "SELECT task_id, project_id, assigned_agent_id FROM tasks WHERE task_id = ?",

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -225,8 +225,8 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             self.assertEqual(
                 alerts_by_id["alert_repeated_failure"]["operator_action"],
                 {
-                    "action": "recover_task",
-                    "label": "Recover task",
+                    "action": "resolve_repeated_failures",
+                    "label": "Resolve repeated failures",
                     "resource_type": "task",
                     "resource_id": repeated_failure_task_id,
                 },

--- a/tests/test_api_board_actions.py
+++ b/tests/test_api_board_actions.py
@@ -356,6 +356,84 @@ class BoardApiActionsTest(unittest.TestCase):
             self.assertEqual(matching_primary["status"], "resolved")
             self.assertEqual(matching_other["status"], "open")
 
+    def test_resolve_repeated_failures_action_resolves_incident_without_recovering_task(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Repeated Failure Triage Test",
+                description="Resolve repeated failure incident without recovering task",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Wire the scheduler and board read model'"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    INSERT INTO failure_log (
+                        failure_id, project_id, task_id, failure_type, summary, detail_json
+                    ) VALUES ('fail_previous', ?, ?, 'session_failed', 'Earlier failure', '{}')
+                    """,
+                    (project_id, task_id),
+                )
+                connection.commit()
+
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting repeated failure triage test",
+                )
+                end_session(connection, session_id, "failed", "Repeated failure")
+
+                repeated_alert = connection.execute(
+                    """
+                    SELECT alert_id, status
+                    FROM alerts
+                    WHERE title = 'Repeated task failures'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+            finally:
+                connection.close()
+
+            self.assertEqual(repeated_alert["status"], "open")
+
+            client = TestClient(create_app(tmpdir))
+            resolve_response = client.post(
+                "/api/tasks/{0}/actions/resolve-repeated-failures".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(resolve_response.status_code, 200)
+            self.assertEqual(resolve_response.json()["resolved_count"], 1)
+            self.assertEqual(resolve_response.json()["status"], "blocked")
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                task = connection.execute(
+                    "SELECT status, review_state FROM tasks WHERE task_id = ?",
+                    (task_id,),
+                ).fetchone()
+                resolved_alert = connection.execute(
+                    """
+                    SELECT status
+                    FROM alerts
+                    WHERE alert_id = ?
+                    """,
+                    (repeated_alert["alert_id"],),
+                ).fetchone()
+            finally:
+                connection.close()
+
+            self.assertEqual(task["status"], "blocked")
+            self.assertEqual(task["review_state"], "session_failed")
+            self.assertEqual(resolved_alert["status"], "resolved")
+
     def test_halt_preserves_paused_agent_state(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Pause Halt Test", description="Pause then halt", project_type="custom")

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -232,6 +232,12 @@ export async function runAlertOperatorAction(operatorAction: AlertOperatorAction
     await postJson(`/api/tasks/${operatorAction.resource_id}/actions/recover`, { actor_id: "agent_allocator" });
     return;
   }
+  if (operatorAction.action === "resolve_repeated_failures") {
+    await postJson(`/api/tasks/${operatorAction.resource_id}/actions/resolve-repeated-failures`, {
+      actor_id: "agent_allocator"
+    });
+    return;
+  }
   await postJson(`/api/agents/${operatorAction.resource_id}/actions/recover`, { actor_id: "agent_allocator" });
 }
 

--- a/web/src/pages/AlertsPage.tsx
+++ b/web/src/pages/AlertsPage.tsx
@@ -50,7 +50,11 @@ export function AlertsPage() {
     try {
       await runAlertOperatorAction(alert.operator_action);
       setAlerts(await fetchAlerts());
-      setNotice(`Recovered ${alert.operator_action.resource_id} from the alert queue.`);
+      if (alert.operator_action.action === "resolve_repeated_failures") {
+        setNotice(`Resolved the repeated-failure incident for ${alert.operator_action.resource_id}.`);
+      } else {
+        setNotice(`Recovered ${alert.operator_action.resource_id} from the alert queue.`);
+      }
     } catch {
       setNotice("Recovery action failed; keep the alert under review.");
     } finally {
@@ -109,6 +113,8 @@ export function AlertsPage() {
                     {pendingAction === `${alert.alert_id}:${alert.operator_action.action}`}
                       ? alert.operator_action.action === "recover_task"
                         ? "Recovering task..."
+                        : alert.operator_action.action === "resolve_repeated_failures"
+                          ? "Resolving repeated failures..."
                         : "Recovering agent..."
                       : alert.operator_action.label}
                   </button>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -197,7 +197,7 @@ export interface AlertItem {
 }
 
 export interface AlertOperatorAction {
-  action: "recover_task" | "recover_agent";
+  action: "recover_task" | "recover_agent" | "resolve_repeated_failures";
   label: string;
   resource_type: "task" | "agent";
   resource_id: string;


### PR DESCRIPTION
## Done on `main`
- [x] Operators can recover failure-blocked tasks
- [x] Operators can recover agents left in `error`
- [x] The Alerts view exposes targeted recovery actions for task-failure and stale-heartbeat incidents

## Working in this PR
- [x] Repeated task failure alerts expose a dedicated incident-resolution action instead of only generic resolve or task recovery
- [x] API and CLI surfaces can resolve repeated-failure incidents without changing task state
- [x] Alerts UI can resolve repeated-failure incidents directly from the alert card
- [x] Regression coverage proves the alert resolves while the task remains blocked

## Still to do
- [ ] Automated restart, retry, and requeue policies
- [ ] DLQ and quarantine workflows
- [ ] Broader self-healing and recovery orchestration

Merged docs continue to track `main` only; branch-local progress is tracked in this PR body.
