### PR TITLE
Add recover-and-requeue task action

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -20,6 +20,7 @@ from maas.services.provider_runtime import list_provider_runtime_status, run_pro
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 from maas.services.security import fetch_task_capabilities
 from maas.services.steering import (
+    recover_and_requeue_task,
     halt_task,
     pause_agent,
     reassign_task,
@@ -464,6 +465,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return recover_task(connection, task_id, payload.actor_id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/tasks/{task_id}/actions/recover-and-requeue")
+    def task_recover_and_requeue_action(task_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return recover_and_requeue_task(connection, task_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -15,7 +15,12 @@ from maas.services.failure_memory import fetch_failure_log
 from maas.services.provider_runtime import run_provider_task
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
-from maas.services.steering import recover_agent, recover_task, resolve_task_repeated_failures
+from maas.services.steering import (
+    recover_agent,
+    recover_and_requeue_task,
+    recover_task,
+    resolve_task_repeated_failures,
+)
 from maas.supervisor import run_supervisor_once
 
 
@@ -70,6 +75,11 @@ def build_parser():
     task_recover_parser.add_argument("--project-root", default=".")
     task_recover_parser.add_argument("--task-id", required=True)
     task_recover_parser.add_argument("--actor-id", required=True)
+
+    task_recover_and_requeue_parser = task_subparsers.add_parser("recover-and-requeue")
+    task_recover_and_requeue_parser.add_argument("--project-root", default=".")
+    task_recover_and_requeue_parser.add_argument("--task-id", required=True)
+    task_recover_and_requeue_parser.add_argument("--actor-id", required=True)
 
     task_resolve_repeated_failures_parser = task_subparsers.add_parser("resolve-repeated-failures")
     task_resolve_repeated_failures_parser.add_argument("--project-root", default=".")
@@ -234,6 +244,8 @@ def command_task(args):
             print(json.dumps(evaluate_task(connection, paths, args.task_id), indent=2))
         elif args.task_command == "recover":
             print(json.dumps(recover_task(connection, args.task_id, args.actor_id), indent=2))
+        elif args.task_command == "recover-and-requeue":
+            print(json.dumps(recover_and_requeue_task(connection, args.task_id, args.actor_id), indent=2))
         elif args.task_command == "resolve-repeated-failures":
             print(json.dumps(resolve_task_repeated_failures(connection, args.task_id, args.actor_id), indent=2))
         elif args.task_command == "allocate":

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -3,6 +3,7 @@
 import json
 
 from maas.ids import generate_id
+from maas.services.scheduler import refresh_ready_tasks
 from maas.services.alerts import resolve_stale_heartbeat_alerts, resolve_task_session_failed_alerts
 from maas.services.failure_memory import resolve_repeated_failure_alerts
 from maas.services.security import (
@@ -173,6 +174,47 @@ def halt_task(connection, task_id, actor_id):
 
 
 def recover_task(connection, task_id, actor_id):
+    task = _load_recoverable_task(connection, task_id, actor_id)
+    _reset_recoverable_task(
+        connection,
+        task,
+        actor_id,
+        audit_action_type="recover_task",
+        activity_action="recovered",
+        activity_description="Task returned to the planning queue after failure recovery.",
+    )
+    connection.commit()
+    return {"task_id": task_id, "status": "planned"}
+
+
+def recover_and_requeue_task(connection, task_id, actor_id):
+    task = _load_recoverable_task(connection, task_id, actor_id)
+    _reset_recoverable_task(
+        connection,
+        task,
+        actor_id,
+        audit_action_type="recover_and_requeue_task",
+        activity_action="recovered_and_requeued",
+        activity_description="Task recovered from failure and returned to readiness evaluation.",
+    )
+    refresh_ready_tasks(connection)
+    refreshed_task = connection.execute(
+        """
+        SELECT status, review_state
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    connection.commit()
+    return {
+        "task_id": task_id,
+        "status": refreshed_task["status"],
+        "review_state": refreshed_task["review_state"],
+    }
+
+
+def _load_recoverable_task(connection, task_id, actor_id):
     task = connection.execute(
         """
         SELECT task_id, project_id, assigned_agent_id, status, review_state
@@ -188,12 +230,15 @@ def recover_task(connection, task_id, actor_id):
         raise ValueError("Only blocked tasks can be recovered")
     if task["review_state"] not in RECOVERABLE_FAILURE_REVIEW_STATES:
         raise ValueError("Task is not blocked by a recoverable failure")
+    return task
 
+
+def _reset_recoverable_task(connection, task, actor_id, audit_action_type, activity_action, activity_description):
     if task["assigned_agent_id"]:
         revoke_task_capabilities(
             connection,
             task["project_id"],
-            task_id,
+            task["task_id"],
             agent_id=task["assigned_agent_id"],
             reason="task_recovered",
             revoked_by=actor_id,
@@ -210,15 +255,15 @@ def recover_task(connection, task_id, actor_id):
             updated_at = CURRENT_TIMESTAMP
         WHERE task_id = ?
         """,
-        (task_id,),
+        (task["task_id"],),
     )
     _audit(
         connection,
         task["project_id"],
         actor_id,
-        "recover_task",
+        audit_action_type,
         "task",
-        task_id,
+        task["task_id"],
         {
             "previous_status": task["status"],
             "previous_review_state": task["review_state"],
@@ -229,26 +274,24 @@ def recover_task(connection, task_id, actor_id):
         connection,
         task["project_id"],
         task["assigned_agent_id"],
-        task_id,
-        "recovered",
-        "Task returned to the planning queue after failure recovery.",
+        task["task_id"],
+        activity_action,
+        activity_description,
     )
     resolve_repeated_failure_alerts(
         connection,
         task["project_id"],
-        task_id,
+        task["task_id"],
         actor_id,
         resolution_reason="task_recovered",
     )
     resolve_task_session_failed_alerts(
         connection,
         task["project_id"],
-        task_id,
+        task["task_id"],
         actor_id,
         reason="task_recovered",
     )
-    connection.commit()
-    return {"task_id": task_id, "status": "planned"}
 
 
 def resolve_task_repeated_failures(connection, task_id, actor_id):

--- a/tests/test_api_board_actions.py
+++ b/tests/test_api_board_actions.py
@@ -434,6 +434,73 @@ class BoardApiActionsTest(unittest.TestCase):
             self.assertEqual(task["review_state"], "session_failed")
             self.assertEqual(resolved_alert["status"], "resolved")
 
+    def test_recover_and_requeue_returns_recoverable_task_to_ready_queue(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Recover And Requeue Test",
+                description="Recover failure-blocked task directly to ready",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Wire the scheduler and board read model'"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting recover-and-requeue test",
+                )
+                end_session(connection, session_id, "failed", "Recoverable failure")
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recover_response = client.post(
+                "/api/tasks/{0}/actions/recover-and-requeue".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(recover_response.status_code, 200)
+            self.assertEqual(recover_response.json()["status"], "ready")
+            self.assertIsNone(recover_response.json()["review_state"])
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                recovered_task = connection.execute(
+                    """
+                    SELECT status, assigned_agent_id, review_state, progress_pct, last_heartbeat_at
+                    FROM tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+                session_failed_alert = connection.execute(
+                    """
+                    SELECT status
+                    FROM alerts
+                    WHERE title = 'Task session failed'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+            finally:
+                connection.close()
+
+            capabilities_response = client.get("/api/tasks/{0}/capabilities".format(task_id))
+            self.assertEqual(capabilities_response.status_code, 200)
+            self.assertEqual(recovered_task["status"], "ready")
+            self.assertIsNone(recovered_task["assigned_agent_id"])
+            self.assertIsNone(recovered_task["review_state"])
+            self.assertEqual(recovered_task["progress_pct"], 0)
+            self.assertIsNone(recovered_task["last_heartbeat_at"])
+            self.assertEqual(capabilities_response.json()["grants"], [])
+            self.assertEqual(session_failed_alert["status"], "resolved")
+
     def test_halt_preserves_paused_agent_state(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Pause Halt Test", description="Pause then halt", project_type="custom")

--- a/tests/test_scheduler_api.py
+++ b/tests/test_scheduler_api.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from maas.api import create_app
 from maas.db import connect
 from maas.services.bootstrap import bootstrap_project
+from maas.services.lifecycle import end_session
 from maas.services.scheduler import evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 
 
@@ -221,12 +222,36 @@ class SchedulerApiTest(unittest.TestCase):
             self.assertEqual(refreshed["status"], "assigned")
             self.assertIsNone(refreshed["review_state"])
             self.assertIsNotNone(refreshed["assigned_agent_id"])
-            self.assertTrue(
-                any(
-                    change["task_id"] == target_task["task_id"] and change["status"] == "assigned"
-                    for change in changed
-                )
+
+    def test_recover_and_requeue_stays_blocked_when_dependency_is_still_open(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Recover And Requeue Dependency Test",
+                description="Recover and requeue with dependency still open",
+                project_type="custom",
             )
+            connection = connect(result["paths"])
+            try:
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Implement FastAPI board endpoint'"
+                ).fetchone()["task_id"]
+                session_id = connection.execute(
+                    "SELECT session_id FROM sessions WHERE task_id = ? AND status = 'active'",
+                    (task_id,),
+                ).fetchone()["session_id"]
+                end_session(connection, session_id, "failed", "Recoverable failure")
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recover_response = client.post(
+                "/api/tasks/{0}/actions/recover-and-requeue".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(recover_response.status_code, 200)
+            self.assertEqual(recover_response.json()["status"], "blocked")
+            self.assertEqual(recover_response.json()["review_state"], "blocked_by_dependency")
 
     def test_scheduler_api_endpoints_work(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -48,6 +48,7 @@ interface TaskCardProps {
   onReassign?: (taskId: string, agentId: string) => void;
   onHalt?: (taskId: string) => void;
   onRecover?: (taskId: string) => void;
+  onRecoverAndRequeue?: (taskId: string) => void;
 }
 
 export function TaskCard({
@@ -59,7 +60,8 @@ export function TaskCard({
   onPriorityChange,
   onReassign,
   onHalt,
-  onRecover
+  onRecover,
+  onRecoverAndRequeue
 }: TaskCardProps) {
   const reviewApproveKey = `review:${task.task_id}:approve`;
   const reviewRejectKey = `review:${task.task_id}:reject`;
@@ -68,6 +70,7 @@ export function TaskCard({
   const reassignKey = `reassign:${task.task_id}`;
   const haltKey = `halt:${task.task_id}`;
   const recoverKey = `recover:${task.task_id}`;
+  const recoverAndRequeueKey = `recover-and-requeue:${task.task_id}`;
   const isPendingReviewApprove = pendingActionKey === reviewApproveKey;
   const isPendingReviewReject = pendingActionKey === reviewRejectKey;
   const isPendingAgentAction = pendingActionKey === agentActionKey;
@@ -75,6 +78,7 @@ export function TaskCard({
   const isPendingReassign = pendingActionKey === reassignKey;
   const isPendingHalt = pendingActionKey === haltKey;
   const isPendingRecover = pendingActionKey === recoverKey;
+  const isPendingRecoverAndRequeue = pendingActionKey === recoverAndRequeueKey;
   const canReview = task.status === "review" && !!onReviewAction;
   const canToggleAgent = !!task.agent?.id && !!onAgentAction && (task.agent?.status === "running" || task.agent?.status === "paused");
   const canSteerTask = task.status !== "done" && task.status !== "cancelled";
@@ -83,6 +87,8 @@ export function TaskCard({
   const canHalt = canSteerTask && !!onHalt;
   const canRecover =
     task.status === "blocked" && !!onRecover && RECOVERABLE_REVIEW_STATES.has(task.review_state ?? "");
+  const canRecoverAndRequeue =
+    task.status === "blocked" && !!onRecoverAndRequeue && RECOVERABLE_REVIEW_STATES.has(task.review_state ?? "");
 
   return (
     <article className={`task-card task-card--${task.status}`}>
@@ -121,7 +127,7 @@ export function TaskCard({
           <dd>{task.failure_count ? `${task.failure_count} logged` : "None"}</dd>
         </div>
       </dl>
-      {(canReview || canToggleAgent || canReassign || canReprioritize || canHalt || canRecover) && (
+      {(canReview || canToggleAgent || canReassign || canReprioritize || canHalt || canRecover || canRecoverAndRequeue) && (
         <div className="task-card__actions">
           {canReview && (
             <>
@@ -210,10 +216,20 @@ export function TaskCard({
             <button
               type="button"
               className="task-action task-action--approve"
-              disabled={isPendingRecover}
+              disabled={isPendingRecover || isPendingRecoverAndRequeue}
               onClick={() => onRecover?.(task.task_id)}
             >
               {isPendingRecover ? "Recovering..." : "Recover task"}
+            </button>
+          )}
+          {canRecoverAndRequeue && (
+            <button
+              type="button"
+              className="task-action task-action--secondary"
+              disabled={isPendingRecover || isPendingRecoverAndRequeue}
+              onClick={() => onRecoverAndRequeue?.(task.task_id)}
+            >
+              {isPendingRecoverAndRequeue ? "Requeueing..." : "Recover + requeue"}
             </button>
           )}
         </div>

--- a/web/src/lib/boardApi.ts
+++ b/web/src/lib/boardApi.ts
@@ -314,3 +314,9 @@ export async function recoverTask(taskId: string) {
     actor_id: DEFAULT_ACTOR_ID
   });
 }
+
+export async function recoverAndRequeueTask(taskId: string) {
+  await postJson(`/api/tasks/${taskId}/actions/recover-and-requeue`, {
+    actor_id: DEFAULT_ACTOR_ID
+  });
+}

--- a/web/src/pages/BoardPage.tsx
+++ b/web/src/pages/BoardPage.tsx
@@ -3,6 +3,7 @@ import {
   fetchBoard,
   haltTask,
   reassignTask,
+  recoverAndRequeueTask,
   recoverTask,
   reprioritizeTask,
   reviewTask,
@@ -187,6 +188,21 @@ export function BoardPage() {
     }
   }
 
+  async function handleRecoverAndRequeue(taskId: string) {
+    const actionKey = `recover-and-requeue:${taskId}`;
+    setPendingActionKey(actionKey);
+    setNotice(null);
+    try {
+      await recoverAndRequeueTask(taskId);
+      setNotice(`Task ${taskId} recovered and requeued.`);
+      await loadBoard();
+    } catch {
+      setNotice("Task recover-and-requeue failed; keep the current board snapshot under review.");
+    } finally {
+      setPendingActionKey(null);
+    }
+  }
+
   return (
     <main className="board-shell">
       <section className="hero-panel">
@@ -304,6 +320,7 @@ export function BoardPage() {
             onReassign={handleReassign}
             onHalt={handleHalt}
             onRecover={handleRecover}
+            onRecoverAndRequeue={handleRecoverAndRequeue}
           />
         ))}
       </section>


### PR DESCRIPTION
## Done on `main`
- [x] Operators can recover failure-blocked tasks back to planning
- [x] Operators can recover agents left in `error`
- [x] Repeated-failure incidents can be resolved without changing task state

## Working in this PR
- [x] Add a dedicated `recover-and-requeue` task action in API and CLI
- [x] Reuse failure recovery cleanup, then immediately re-run readiness evaluation
- [x] Surface `Recover + requeue` on blocked failure tasks in the board UI
- [x] Cover both outcomes: task becomes `ready` when unblocked, or remains dependency-blocked when it still cannot run

## Still to do
- [ ] Automated restart and retry policies
- [ ] DLQ and quarantine workflows
- [ ] Broader self-healing and recovery orchestration

Merged docs continue to track `main` only; branch-local progress is tracked in this PR body.
