### PR TITLE
Expose quarantine details in failure reads

### DIFF
--- a/src/maas/services/dashboard.py
+++ b/src/maas/services/dashboard.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 
 from maas.services.escalations import fetch_escalations
-from maas.services.failure_memory import fetch_repeated_failure_tasks, repeated_failure_task_count
+from maas.services.failure_memory import enrich_failures_with_quarantine, fetch_repeated_failure_tasks, repeated_failure_task_count
 
 
 def _parse_timestamp(value):
@@ -103,6 +103,7 @@ def fetch_overview(connection):
             SELECT
                 failure_log.failure_id,
                 failure_log.task_id,
+                failure_log.session_id,
                 failure_log.failure_type,
                 failure_log.summary,
                 failure_log.created_at,
@@ -114,6 +115,7 @@ def fetch_overview(connection):
             """
         ).fetchall()
     ]
+    recent_failures = enrich_failures_with_quarantine(connection, recent_failures)
     repeated_failure_tasks = fetch_repeated_failure_tasks(connection, limit=5)
     escalation_summary = fetch_escalations(connection)["summary"]
 

--- a/src/maas/services/failure_memory.py
+++ b/src/maas/services/failure_memory.py
@@ -279,6 +279,50 @@ def resolve_repeated_failure_alerts(connection, project_id, task_id, actor_id, r
     return resolved_alert_ids
 
 
+def _quarantined_artifacts_by_session(connection, session_ids):
+    if not session_ids:
+        return {}
+
+    placeholders = ", ".join(["?"] * len(session_ids))
+    rows = connection.execute(
+        """
+        SELECT session_id, artifact_id, path, metadata_json
+        FROM artifacts
+        WHERE session_id IN ({0})
+        """.format(placeholders),
+        tuple(session_ids),
+    ).fetchall()
+
+    artifacts_by_session = {}
+    for row in rows:
+        metadata = json.loads(row["metadata_json"] or "{}")
+        if not metadata.get("quarantined"):
+            continue
+        artifacts_by_session.setdefault(row["session_id"], []).append(
+            {
+                "artifact_id": row["artifact_id"],
+                "path": row["path"],
+                "quarantine_reason": metadata.get("quarantine_reason"),
+                "quarantined_from_path": metadata.get("quarantined_from_path"),
+            }
+        )
+
+    return artifacts_by_session
+
+
+def enrich_failures_with_quarantine(connection, failures):
+    session_ids = [failure["session_id"] for failure in failures if failure.get("session_id")]
+    artifacts_by_session = _quarantined_artifacts_by_session(connection, session_ids)
+    enriched = []
+    for failure in failures:
+        quarantined_artifacts = artifacts_by_session.get(failure.get("session_id"), [])
+        enriched_failure = dict(failure)
+        enriched_failure["quarantined_artifacts"] = quarantined_artifacts
+        enriched_failure["quarantined_artifact_count"] = len(quarantined_artifacts)
+        enriched.append(enriched_failure)
+    return enriched
+
+
 def fetch_failure_log(connection, limit=20):
     rows = connection.execute(
         """
@@ -303,7 +347,7 @@ def fetch_failure_log(connection, limit=20):
         (limit,),
     ).fetchall()
 
-    recent = [dict(row) for row in rows]
+    recent = enrich_failures_with_quarantine(connection, [dict(row) for row in rows])
     repeated_tasks = fetch_repeated_failure_tasks(connection)
 
     return {

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -8,6 +9,7 @@ from maas.api import create_app
 from maas.db import connect, project_paths
 from maas.services.bootstrap import bootstrap_project
 from maas.services.escalations import request_escalation
+from maas.services.lifecycle import end_session, produce_artifact, start_session
 from maas.services.live import build_live_snapshot
 
 
@@ -71,6 +73,52 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             failures_payload = failures_response.json()
             self.assertEqual(failures_payload["summary"]["total_failures"], 1)
             self.assertEqual(failures_payload["recent"][0]["failure_type"], "session_failed")
+
+    def test_failures_api_exposes_quarantined_artifacts_for_failed_sessions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(tmpdir, name="Failure Quarantine API Test", description="Failure quarantine api test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting failure quarantine api test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "failure-api-note.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("quarantine api\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with quarantined artifact",
+                    project_paths=result["paths"],
+                )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            failures_payload = client.get("/api/failures").json()
+            recent_failure = failures_payload["recent"][0]
+
+            self.assertEqual(recent_failure["failure_type"], "session_failed")
+            self.assertEqual(recent_failure["quarantined_artifact_count"], 1)
+            self.assertEqual(recent_failure["quarantined_artifacts"][0]["quarantined_from_path"], artifact_path)
 
     def test_live_snapshot_includes_open_escalation_count(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 
@@ -8,6 +9,7 @@ from maas.db import connect, project_paths
 from maas.ids import generate_id
 from maas.services.bootstrap import bootstrap_project
 from maas.services.escalations import request_escalation
+from maas.services.lifecycle import end_session, produce_artifact, start_session
 
 
 class DashboardApiTest(unittest.TestCase):
@@ -94,6 +96,57 @@ class DashboardApiTest(unittest.TestCase):
             self.assertEqual(overview_payload["summary"]["repeated_failure_tasks"], 6)
             self.assertEqual(len(overview_payload["repeated_failures"]), 5)
             self.assertEqual(live_payload["counts"]["repeated_failure_tasks"], 6)
+
+    def test_overview_recent_failures_include_quarantined_artifact_counts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Dashboard Quarantine Test",
+                description="Dashboard quarantine test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting dashboard quarantine test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "dashboard-quarantine-note.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("dashboard quarantine\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Dashboard failure with quarantined artifact",
+                    project_paths=result["paths"],
+                )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            overview_payload = client.get("/api/overview").json()
+            recent_failure = overview_payload["recent_failures"][0]
+
+            self.assertEqual(recent_failure["failure_type"], "session_failed")
+            self.assertEqual(recent_failure["quarantined_artifact_count"], 1)
+            self.assertEqual(recent_failure["quarantined_artifacts"][0]["quarantined_from_path"], artifact_path)
 
     def test_agent_roster_is_enriched(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -165,6 +165,11 @@ export function OverviewPage() {
                 <div>
                   <strong>{item.task_title ?? item.task_id ?? "Unlinked failure"}</strong>
                   <p>{item.summary}</p>
+                  {item.quarantined_artifact_count ? (
+                    <p>
+                      Quarantined artifacts: {item.quarantined_artifact_count}
+                    </p>
+                  ) : null}
                 </div>
                 <div className="data-list__meta">
                   <span>{item.failure_type}</span>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -144,7 +144,16 @@ export interface FailureItem {
   failure_type: string;
   summary: string;
   detail_json?: string;
+  quarantined_artifact_count?: number;
+  quarantined_artifacts?: QuarantinedArtifactItem[];
   created_at: string;
+}
+
+export interface QuarantinedArtifactItem {
+  artifact_id: string;
+  path: string;
+  quarantine_reason?: string | null;
+  quarantined_from_path?: string | null;
 }
 
 export interface RepeatedFailureItem {


### PR DESCRIPTION
## Done on `main`
- [x] Failed-session and timed-out-session artifacts are quarantined into `.maas/quarantine/`
- [x] Operators can recover, recover-and-requeue, and triage repeated failures
- [x] Alert-linked recovery actions exist for recoverable incidents

## Working in this PR
- [x] Failure API recent entries expose quarantined artifact details and counts
- [x] Overview recent failures expose the same quarantine visibility
- [x] Overview UI shows when a recent failure quarantined artifacts
- [x] Regression coverage locks the quarantine visibility contract for both `/api/failures` and `/api/overview`

## Still to do
- [ ] Automated restart and retry policies
- [ ] Broader DLQ workflows beyond quarantining failed-session artifacts
- [ ] Broader self-healing and recovery orchestration

Merged docs continue to track `main` only; branch-local progress is tracked in this PR body.
