### PR TITLE
Add control-room failures page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Legend:
 - [x] Ready-queue refresh, acceptance evaluation, and first-pass idle-agent allocation
 - [x] Steering controls for review, reprioritize, reassign, pause/resume, and halt
 - [x] Escalation queue for risky steering approvals
-- [x] Failure-memory logging, repeated-failure alerts, incident-specific alert actions, and task recovery for failure-blocked work
+- [x] Failure-memory logging, quarantine visibility, repeated-failure alerts, incident-specific alert actions, and task recovery for failure-blocked work
 - [x] Manual recover-and-requeue for failure-blocked tasks
 - [x] Recovery for agents left in `error`
 
@@ -123,6 +123,7 @@ These commands expose the current dependency-aware ready queue, allocator flow, 
 - board cards and the task capabilities API expose the currently active task grants
 - risky task and agent interventions can now be routed through an escalation queue instead of being executed immediately
 - failed and timed-out sessions are now recorded in failure memory and can raise repeated-failure alerts
+- quarantined failure artifacts are isolated under `.maas/quarantine/` and surfaced through the failure-memory reads
 - operators can return failure-blocked tasks to the planning queue without resuming the old execution context
 - operators can recover timeout-stranded agents from `error` back to `idle` once no active session remains
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -21,7 +21,7 @@ Legend for the checklist column:
 | 4. Greenfield onboarding | `[x]` | `maas init`, generated workspace, seeded backlog, project-understanding artifact |
 | 5. Supervisor, dashboard, and Kanban V1 | `[ ]` | Board API, board UI, control-room views, supervisor loop, ready refresh, idle-agent allocation, overview/roster operator controls, roster/overview/goal tree reads |
 | 6. Security and human steering | `[ ]` | Review, reprioritize, reassign, pause/resume, halt actions with audit logging, board controls, role-baseline gating, task-scoped execution grants, and escalation queue approvals |
-| 7. Resilience and failure memory | `[ ]` | Stale-session detection, failure logging for failed/timed-out sessions, repeated-failure alerts, read-model visibility, incident-specific alert actions, and task plus agent recovery exist; broader recovery is still pending |
+| 7. Resilience and failure memory | `[ ]` | Stale-session detection, failure logging for failed/timed-out sessions, quarantine isolation and visibility, repeated-failure alerts, read-model visibility, incident-specific alert actions, and task plus agent recovery exist; broader recovery is still pending |
 | 8. Brownfield and multi-project | `[ ]` | Still roadmap only |
 
 ## Delivery Order

--- a/docs/implementation/05-supervisor-dashboard-and-kanban-v1.md
+++ b/docs/implementation/05-supervisor-dashboard-and-kanban-v1.md
@@ -10,7 +10,7 @@
 - [x] Alert creation for stale sessions
 - [x] Task-first `/api/board` response
 - [x] React board shell as the primary operator view
-- [x] Supporting reads for goals, agents, activity, alerts, and providers
+- [x] Supporting reads for overview, goals, agents, activity, alerts, failures, escalations, and providers
 - [x] Operator controls for manual supervisor runs and assign-next actions
 - [x] Current implementation includes a `cancelled` board column so halted work remains visible to operators
 

--- a/docs/implementation/07-resilience-and-failure-memory.md
+++ b/docs/implementation/07-resilience-and-failure-memory.md
@@ -13,6 +13,8 @@
 - [x] Failed sessions and timed-out sessions write into `failure_log`
 - [x] The supervisor raises a critical alert when the same task accumulates repeated failures
 - [x] Board cards, overview, live snapshot, and a dedicated failures API expose failure-memory state
+- [x] Failed and timed-out session artifacts are isolated under `.maas/quarantine/`
+- [x] Quarantine details are visible in failure reads and overview failure surfaces
 - [x] Operators can resolve repeated-failure incidents from the Alerts view without changing task state
 - [x] Operators can recover failure-blocked tasks
 - [x] Operators can recover-and-requeue failure-blocked tasks
@@ -21,7 +23,7 @@
 ## Still To Do On `main`
 
 - [ ] Automated restart policies
-- [ ] DLQ and quarantine workflows
+- [ ] Broader DLQ and quarantine workflows
 - [ ] Broader automated recovery orchestration
 
 ## Non-Goals
@@ -33,5 +35,6 @@
 
 - [x] Stale sessions move to timeout and produce an alert
 - [x] Repeated failed work can be surfaced for human review
-- [ ] Quarantined artifacts are isolated from normal flow
+- [x] Quarantined artifacts are isolated from normal flow
 - [x] Failed sessions create failure-memory records and block the affected task for follow-up
+- [x] Operators can inspect quarantine details through failure reads

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -63,6 +63,7 @@
 - [x] Failure-memory logging for failed and timed-out sessions
 - [x] Repeated-failure alerts for tasks with repeated failures
 - [x] Failure visibility in board, overview, live, and dedicated failures reads
+- [x] Quarantine details are visible in recent failure reads and the control-room failure surfaces
 - [x] Failure-specific operator actions for repeated-failure incidents and recovery-linked alerts
 - [x] Operator recovery for failure-blocked tasks
 - [x] Operator recover-and-requeue for failure-blocked tasks

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,10 +4,11 @@ import { AgentRosterPage } from "./pages/AgentRosterPage";
 import { AlertsPage } from "./pages/AlertsPage";
 import { BoardPage } from "./pages/BoardPage";
 import { EscalationsPage } from "./pages/EscalationsPage";
+import { FailuresPage } from "./pages/FailuresPage";
 import { GoalTreePage } from "./pages/GoalTreePage";
 import { OverviewPage } from "./pages/OverviewPage";
 
-type View = "overview" | "board" | "goals" | "agents" | "activity" | "alerts" | "escalations";
+type View = "overview" | "board" | "goals" | "agents" | "activity" | "failures" | "alerts" | "escalations";
 
 const VIEWS: { id: View; label: string }[] = [
   { id: "overview", label: "Overview" },
@@ -15,6 +16,7 @@ const VIEWS: { id: View; label: string }[] = [
   { id: "goals", label: "Goal Tree" },
   { id: "agents", label: "Agent Roster" },
   { id: "activity", label: "Activity" },
+  { id: "failures", label: "Failures" },
   { id: "alerts", label: "Alerts" },
   { id: "escalations", label: "Escalations" }
 ];
@@ -70,6 +72,7 @@ export default function App() {
         {activeView === "goals" ? <GoalTreePage /> : null}
         {activeView === "agents" ? <AgentRosterPage /> : null}
         {activeView === "activity" ? <ActivityPage /> : null}
+        {activeView === "failures" ? <FailuresPage /> : null}
         {activeView === "alerts" ? <AlertsPage /> : null}
         {activeView === "escalations" ? <EscalationsPage /> : null}
       </div>

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -4,6 +4,7 @@ import type {
   AlertOperatorAction,
   AlertsResponse,
   EscalationsResponse,
+  FailuresResponse,
   GoalTreeResponse,
   LiveSnapshot,
   OverviewResponse,
@@ -144,6 +145,16 @@ const ESCALATIONS_FALLBACK: EscalationsResponse = {
   }
 };
 
+const FAILURES_FALLBACK: FailuresResponse = {
+  recent: [],
+  repeated_tasks: [],
+  summary: {
+    total_failures: 0,
+    tasks_with_failures: 0,
+    repeated_tasks: 0
+  }
+};
+
 const LIVE_FALLBACK: LiveSnapshot = {
   generated_at: new Date().toISOString(),
   counts: {
@@ -197,6 +208,10 @@ export function fetchAlerts() {
 
 export function fetchEscalations() {
   return fetchJson<EscalationsResponse>("/api/escalations", ESCALATIONS_FALLBACK);
+}
+
+export function fetchFailures() {
+  return fetchJson<FailuresResponse>("/api/failures", FAILURES_FALLBACK);
 }
 
 export function fetchLiveSnapshot() {

--- a/web/src/pages/FailuresPage.tsx
+++ b/web/src/pages/FailuresPage.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { fetchFailures } from "../lib/controlRoomApi";
+import { useLivePulse } from "../lib/useLivePulse";
+import type { FailuresResponse } from "../types";
+import { StatCard } from "../components/StatCard";
+
+export function FailuresPage() {
+  const [failures, setFailures] = useState<FailuresResponse | null>(null);
+  const livePulse = useLivePulse();
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadFailures() {
+      const payload = await fetchFailures();
+      if (mounted) {
+        setFailures(payload);
+      }
+    }
+
+    void loadFailures();
+    return () => {
+      mounted = false;
+    };
+  }, [livePulse]);
+
+  return (
+    <section className="control-page">
+      <header className="page-hero">
+        <div>
+          <span className="eyebrow">Failures</span>
+          <h1>Failure memory and quarantine</h1>
+          <p>Inspect recent failed or timed-out work, repeated incidents, and any artifacts isolated from normal flow.</p>
+        </div>
+      </header>
+
+      <section className="stats-grid">
+        <StatCard label="Failures logged" value={failures?.summary.total_failures ?? 0} tone="warn" />
+        <StatCard label="Tasks hit" value={failures?.summary.tasks_with_failures ?? 0} />
+        <StatCard label="Repeated tasks" value={failures?.summary.repeated_tasks ?? 0} tone="warn" />
+      </section>
+
+      <section className="overview-grid">
+        <article className="data-panel">
+          <header className="data-panel__header">
+            <div>
+              <h2>Recent failures</h2>
+              <p>Latest failed or timed-out sessions, including quarantine details when artifacts were isolated.</p>
+            </div>
+          </header>
+          <div className="data-list">
+            {(failures?.recent ?? []).map((item) => (
+              <div key={item.failure_id ?? `${item.task_id}-${item.created_at}`} className="data-list__item">
+                <div>
+                  <strong>{item.task_title ?? item.task_id ?? "Unlinked failure"}</strong>
+                  <p>{item.summary}</p>
+                  {item.quarantined_artifact_count ? (
+                    <p>
+                      Quarantined artifacts: {item.quarantined_artifact_count}
+                      {item.quarantined_artifacts?.[0]?.quarantined_from_path
+                        ? ` from ${item.quarantined_artifacts[0].quarantined_from_path}`
+                        : ""}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="data-list__meta">
+                  <span>{item.failure_type}</span>
+                  <span>{new Date(item.created_at).toLocaleString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        <article className="data-panel">
+          <header className="data-panel__header">
+            <div>
+              <h2>Repeated failure tasks</h2>
+              <p>Tasks that have crossed the repeated-failure threshold and should stay under explicit operator review.</p>
+            </div>
+          </header>
+          <div className="data-list">
+            {(failures?.repeated_tasks ?? []).map((item) => (
+              <div key={item.task_id} className="data-list__item">
+                <div>
+                  <strong>{item.task_title ?? item.task_id}</strong>
+                  <p>{item.failure_count} logged failures</p>
+                </div>
+                <div className="data-list__meta">
+                  <span>{item.task_id}</span>
+                  <span>
+                    {item.latest_failure_at ? new Date(item.latest_failure_at).toLocaleString() : "No timestamp"}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+      </section>
+    </section>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -163,6 +163,16 @@ export interface RepeatedFailureItem {
   latest_failure_at?: string | null;
 }
 
+export interface FailuresResponse {
+  recent: FailureItem[];
+  repeated_tasks: RepeatedFailureItem[];
+  summary: {
+    total_failures: number;
+    tasks_with_failures: number;
+    repeated_tasks: number;
+  };
+}
+
 export interface GoalTreeNode {
   goal_id: string;
   parent_goal_id?: string | null;


### PR DESCRIPTION
## Done on main
- [x] Failure memory exists for failed and timed-out sessions, including repeated-failure alerts, recovery actions, and quarantine-backed failure reads.
- [x] Operators can already inspect recent failures through `/api/failures`, overview reads, and the existing board/alerts/live surfaces.
- [x] The implementation docs now explicitly call out shipped quarantine isolation and visibility in the resilience docs.

## Working in this PR
- [x] Add a dedicated `Failures` view to the React control room navigation.
- [x] Render failure totals, recent failure records, repeated-failure tasks, and quarantine details from the existing `/api/failures` contract.
- [x] Extend the typed frontend client with a `FailuresResponse` contract and fallback handling.
- [x] Update repo docs where needed without marking this new page as already shipped on `main`.

## Still to do
- [ ] Frontend build validation in an environment with local `tsc` installed.
- [ ] Broader DLQ and quarantine workflows beyond the current isolation and visibility.
- [ ] Automated restart, retry, and recovery orchestration beyond the current operator-driven flows.

## Validation
- [x] `git diff --check`
- [ ] Frontend build not run in this checkout because local `tsc` is not installed.
