### PR TITLE
Add Claude Code CLI provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Legend:
 - [x] Timed-out session auto-retry with tracked retry state
 - [x] Quarantine queue workflow with restore and dismiss actions
 - [x] Recovery for agents left in `error`
+- [x] Real local OpenAI Codex CLI integration behind explicit provider config
 
 ### Still to do on `main`
 
-- [ ] Real external provider integrations
+- [ ] Real external Claude Code integration
 - [ ] Broader automated restart, retry, backoff, and DLQ workflows
 - [ ] Brownfield onboarding and multi-project support
 
@@ -140,4 +141,5 @@ These commands expose the current dependency-aware ready queue, allocator flow, 
 ## Provider Notes
 
 - `python_script` is the reference local worker adapter
-- `claude_code` and `openai_codex` now execute through concrete simulated adapters, producing provider-specific activity and artifacts without live external API calls
+- `claude_code` executes through a concrete simulated adapter today, producing provider-specific activity and artifacts without live external API calls
+- `openai_codex` supports both the simulated adapter and a real local `codex exec` path when enabled in `project.yaml`

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -17,7 +17,7 @@ Legend for the checklist column:
 |---|---|---|
 | 1. Core kernel and scaffold | `[x]` | Python package, CLI, SQLite migrations, `.maas/` workspace, `project.yaml`, greenfield bootstrap |
 | 2. Goal/task engine | `[ ]` | Goal records, task DAG storage, board-visible task states, dependency-aware ready refresh, acceptance evaluation, first-pass assignment |
-| 3. Runtime lifecycle and adapters | `[ ]` | Lifecycle operations, API/CLI entrypoints, provider registry, and concrete simulated adapters for Python Script, Claude Code, and OpenAI Codex |
+| 3. Runtime lifecycle and adapters | `[ ]` | Lifecycle operations, API/CLI entrypoints, provider registry, concrete simulated adapters for Python Script, Claude Code, and OpenAI Codex, plus a local Codex CLI path |
 | 4. Greenfield onboarding | `[x]` | `maas init`, generated workspace, seeded backlog, project-understanding artifact |
 | 5. Supervisor, dashboard, and Kanban V1 | `[ ]` | Board API, board UI, control-room views, supervisor loop, ready refresh, idle-agent allocation, overview/roster operator controls, roster/overview/goal tree reads |
 | 6. Security and human steering | `[ ]` | Review, reprioritize, reassign, pause/resume, halt actions with audit logging, board controls, role-baseline gating, task-scoped execution grants, and escalation queue approvals |
@@ -59,6 +59,7 @@ This repository now includes:
 - [x] Escalation queue storage plus operator approve/reject flows for risky steering actions
 - [x] Failure-log storage plus read models for recent failures and repeated-failure tasks
 - [x] Concrete simulated provider adapters for Python Script, Claude Code, and OpenAI Codex
+- [x] Local OpenAI Codex CLI integration behind explicit provider config
 - [x] Lifecycle API/CLI surface
 - [x] A React control-room shell under `web/` with Board, Overview, Goal Tree, Agent Roster, Activity, Alerts, and Escalations views
 

--- a/docs/implementation/03-runtime-lifecycle-and-adapters.md
+++ b/docs/implementation/03-runtime-lifecycle-and-adapters.md
@@ -13,10 +13,12 @@
 - [x] Provider execution routed through concrete local adapters for `python_script`, `claude_code`, and `openai_codex`
 - [x] Provider runs create provider-specific activity entries and artifacts while still using the shared lifecycle contract
 - [x] Lifecycle starts validate `provider_type` against the provider registry
+- [x] `openai_codex` can run through a real local Codex CLI path when explicitly enabled in project config
 
 ## Still To Do On `main`
 
-- [ ] Live external provider APIs and CLI integrations
+- [ ] Real external Claude Code integration
+- [ ] Broader external provider coverage beyond the first Codex CLI path
 
 ## Non-Goals
 

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -38,6 +38,7 @@
 - [x] Simulated local worker/runtime execution path
 - [x] Provider-dispatched runtime path for `python_script`, `claude_code`, and `openai_codex`
 - [x] Shared lifecycle contract for provider activity and artifact output
+- [x] Real local OpenAI Codex CLI execution path behind explicit provider config
 
 ### Control room and steering
 
@@ -82,7 +83,6 @@
 ### Providers
 
 - [ ] Real external Claude Code integration
-- [ ] Real external OpenAI Codex integration
 - [ ] More complete provider runtime lifecycle coverage
 
 ### Resilience and recovery

--- a/src/maas/config.py
+++ b/src/maas/config.py
@@ -72,6 +72,13 @@ def build_default_project_config(name, description, project_type):
             "retry_backoff_max_seconds": 900,
         },
         "providers": {
+            "claude_code": {
+                "mode": "simulated",
+                "cli_command": "claude",
+                "timeout_seconds": 300,
+                "permission_mode": "acceptEdits",
+                "model": "",
+            },
             "openai_codex": {
                 "mode": "simulated",
                 "cli_command": "codex",

--- a/src/maas/providers.py
+++ b/src/maas/providers.py
@@ -99,6 +99,11 @@ def list_provider_status(connection=None, project_id=None):
                 provider["configured_execution_mode"] = "local_simulation"
             else:
                 provider["configured_execution_mode"] = configured_mode
+            if provider["id"] == "claude_code" and configured_mode == "claude_cli":
+                provider["execution_mode"] = "claude_cli"
+                provider["status"] = "configured"
+                provider["supports_live_api"] = True
+                provider["notes"] = "Local Claude Code CLI integration enabled by project config."
             if provider["id"] == "openai_codex" and configured_mode == "codex_cli":
                 provider["execution_mode"] = "codex_cli"
                 provider["status"] = "configured"

--- a/src/maas/services/provider_runtime.py
+++ b/src/maas/services/provider_runtime.py
@@ -171,6 +171,31 @@ def _codex_cli_activity_details(project_paths, provider_settings, task_prompt):
     }
 
 
+def _claude_cli_command(project_paths, provider_settings, prompt):
+    command = [
+        provider_settings.get("cli_command") or "claude",
+        "-p",
+    ]
+    permission_mode = (provider_settings.get("permission_mode") or "").strip()
+    if permission_mode:
+        command.extend(["--permission-mode", permission_mode])
+    model = (provider_settings.get("model") or "").strip()
+    if model:
+        command.extend(["--model", model])
+    command.extend(["--add-dir", project_paths.root])
+    command.append(prompt)
+    return command
+
+
+def _claude_cli_activity_details(project_paths, provider_settings, task_prompt):
+    command = _claude_cli_command(project_paths, provider_settings, task_prompt)
+    return {
+        "command": command,
+        "timeout_seconds": int(provider_settings.get("timeout_seconds") or 300),
+        "external_runtime": "claude_cli",
+    }
+
+
 def _run_openai_codex_cli(project_paths, provider_settings, task_prompt):
     timeout_seconds = int(provider_settings.get("timeout_seconds") or 300)
     os.makedirs(project_paths.runtime_dir, exist_ok=True)
@@ -208,6 +233,44 @@ def _run_openai_codex_cli(project_paths, provider_settings, task_prompt):
             os.remove(output_path)
 
 
+def _run_claude_code_cli(project_paths, provider_settings, task_prompt):
+    timeout_seconds = int(provider_settings.get("timeout_seconds") or 300)
+    command = _claude_cli_command(project_paths, provider_settings, task_prompt)
+    result = subprocess.run(
+        command,
+        cwd=project_paths.root,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Claude CLI exited with status {0}: {1}".format(result.returncode, (result.stderr or "").strip() or "unknown error")
+        )
+    return {
+        "summary_text": (result.stdout or "").strip() or "Claude CLI completed without a final message.",
+        "stdout": result.stdout or "",
+        "stderr": result.stderr or "",
+    }
+
+
+def _claude_cli_artifact_payload(provider, task_id, external_result):
+    return {
+        "artifact_type": provider["default_artifact_type"],
+        "content": (
+            "# Claude Code Runtime Report\n\n"
+            "- Task ID: {0}\n"
+            "- Provider: Claude Code CLI\n"
+            "- Outcome: External Claude CLI execution completed.\n\n"
+            "## Final Message\n\n{1}\n\n"
+            "## Stdout\n\n```\n{2}\n```\n\n"
+            "## Stderr\n\n```\n{3}\n```\n"
+        ).format(task_id, external_result["summary_text"], external_result["stdout"].strip(), external_result["stderr"].strip()),
+        "status_message": "Claude Code CLI completed task execution",
+    }
+
+
 def _codex_cli_artifact_payload(provider, task_id, external_result):
     return {
         "artifact_type": provider["default_artifact_type"],
@@ -228,8 +291,14 @@ def run_provider_task(connection, project_paths, project_id, agent_id, task_id, 
     provider = get_provider(provider_type)
     task_title = _task_title(connection, task_id)
     provider_settings = _project_provider_settings(connection, project_id, provider_type)
+    claude_cli_enabled = provider_type == "claude_code" and provider_settings.get("mode") == "claude_cli"
     codex_cli_enabled = provider_type == "openai_codex" and provider_settings.get("mode") == "codex_cli"
-    if codex_cli_enabled:
+    if claude_cli_enabled:
+        provider["execution_mode"] = "claude_cli"
+        provider["status"] = "configured"
+        task_prompt = _task_prompt(connection, task_id)
+        extra_activity_details = _claude_cli_activity_details(project_paths, provider_settings, task_prompt)
+    elif codex_cli_enabled:
         provider["execution_mode"] = "codex_cli"
         provider["status"] = "configured"
         task_prompt = _task_prompt(connection, task_id)
@@ -301,7 +370,10 @@ def run_provider_task(connection, project_paths, project_id, agent_id, task_id, 
             artifact_type=provider["default_artifact_type"],
             **extra_activity_details
         )
-        if codex_cli_enabled:
+        if claude_cli_enabled:
+            external_result = _run_claude_code_cli(project_paths, provider_settings, task_prompt)
+            artifact_payload = _claude_cli_artifact_payload(provider, task_id, external_result)
+        elif codex_cli_enabled:
             external_result = _run_openai_codex_cli(project_paths, provider_settings, task_prompt)
             artifact_payload = _codex_cli_artifact_payload(provider, task_id, external_result)
         else:

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -36,6 +36,23 @@ def _insert_assigned_task(connection, project_id, goal_id, agent_id, title):
 
 
 class ProviderRuntimeTest(unittest.TestCase):
+    def _enable_claude_code_cli(self, connection):
+        project = connection.execute("SELECT project_id, config_json FROM projects LIMIT 1").fetchone()
+        config = json.loads(project["config_json"] or "{}")
+        providers = config.setdefault("providers", {})
+        providers["claude_code"] = {
+            "mode": "claude_cli",
+            "cli_command": "claude",
+            "timeout_seconds": 120,
+            "permission_mode": "acceptEdits",
+            "model": "sonnet",
+        }
+        connection.execute(
+            "UPDATE projects SET config_json = ? WHERE project_id = ?",
+            (json.dumps(config), project["project_id"]),
+        )
+        return project["project_id"]
+
     def _enable_openai_codex_cli(self, connection):
         project = connection.execute("SELECT project_id, config_json FROM projects LIMIT 1").fetchone()
         config = json.loads(project["config_json"] or "{}")
@@ -100,6 +117,25 @@ class ProviderRuntimeTest(unittest.TestCase):
             self.assertEqual(providers["openai_codex"]["configured_execution_mode"], "codex_cli")
             self.assertEqual(providers["openai_codex"]["status"], "configured")
             self.assertTrue(providers["openai_codex"]["supports_live_api"])
+
+    def test_providers_endpoint_reflects_configured_claude_code_cli_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Claude Provider Config Test", description="Claude provider config test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                self._enable_claude_code_cli(connection)
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            payload = client.get("/api/providers").json()
+            providers = {provider["id"]: provider for provider in payload["providers"]}
+
+            self.assertEqual(providers["claude_code"]["execution_mode"], "claude_cli")
+            self.assertEqual(providers["claude_code"]["configured_execution_mode"], "claude_cli")
+            self.assertEqual(providers["claude_code"]["status"], "configured")
+            self.assertTrue(providers["claude_code"]["supports_live_api"])
 
     def test_provider_run_task_executes_each_adapter_end_to_end(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -358,6 +394,87 @@ class ProviderRuntimeTest(unittest.TestCase):
                 all(json.loads(row["details_json"]).get("external_runtime") == "codex_cli" for row in activity_rows)
             )
 
+    def test_claude_code_cli_mode_executes_real_command_path_when_enabled(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Claude CLI Test", description="Claude CLI test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = self._enable_claude_code_cli(connection)
+                goal_id = connection.execute("SELECT goal_id FROM goals ORDER BY created_at ASC LIMIT 1").fetchone()["goal_id"]
+                task_id = _insert_assigned_task(connection, project_id, goal_id, "agent_researcher", "Run Claude CLI adapter")
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+
+            def write_claude_output(command, cwd, capture_output, text, timeout, check):
+                self.assertEqual(command[0:2], ["claude", "-p"])
+                self.assertIn("--permission-mode", command)
+                self.assertIn("--add-dir", command)
+                completed = mock.Mock()
+                completed.returncode = 0
+                completed.stdout = "Claude completed the task.\n"
+                completed.stderr = ""
+                return completed
+
+            with mock.patch("maas.services.provider_runtime.subprocess.run", side_effect=write_claude_output) as run_mock:
+                response = client.post(
+                    "/api/providers/claude_code/actions/run-task",
+                    json={
+                        "project_id": project_id,
+                        "agent_id": "agent_researcher",
+                        "task_id": task_id,
+                    },
+                )
+
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["execution"]["execution_mode"], "claude_cli")
+            self.assertEqual(payload["provider"]["status"], "configured")
+            self.assertEqual(run_mock.call_count, 1)
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                artifact = connection.execute(
+                    """
+                    SELECT artifact_type, metadata_json, path
+                    FROM artifacts
+                    WHERE task_id = ?
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+                with open(artifact["path"], "r", encoding="utf-8") as handle:
+                    artifact_content = handle.read()
+                activity_rows = connection.execute(
+                    """
+                    SELECT action, details_json
+                    FROM activity_log
+                    WHERE task_id = ? AND action IN (
+                        'provider_adapter_started',
+                        'provider_workspace_prepared',
+                        'provider_execution_progress',
+                        'provider_artifact_recorded',
+                        'provider_adapter_completed'
+                    )
+                    ORDER BY rowid ASC
+                    """,
+                    (task_id,),
+                ).fetchall()
+            finally:
+                connection.close()
+
+            self.assertEqual(artifact["artifact_type"], "provider_report")
+            self.assertIn("Claude completed the task.", artifact_content)
+            artifact_metadata = json.loads(artifact["metadata_json"])
+            self.assertEqual(artifact_metadata["execution_mode"], "claude_cli")
+            self.assertEqual(len(activity_rows), 5)
+            self.assertTrue(
+                all(json.loads(row["details_json"]).get("external_runtime") == "claude_cli" for row in activity_rows)
+            )
+
     def test_provider_run_task_rejects_paths_outside_workspace(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Provider Path Test", description="Provider path test", project_type="custom")
@@ -604,6 +721,46 @@ class ProviderRuntimeTest(unittest.TestCase):
             self.assertTrue(os.path.exists(artifact_full_path))
             with open(artifact_full_path, "r", encoding="utf-8") as handle:
                 self.assertEqual(handle.read(), "preexisting codex artifact")
+
+    def test_claude_code_cli_failure_preserves_preexisting_artifact(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Claude CLI Failure Test", description="Claude CLI failure test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = self._enable_claude_code_cli(connection)
+                goal_id = connection.execute("SELECT goal_id FROM goals ORDER BY created_at ASC LIMIT 1").fetchone()["goal_id"]
+                task_id = _insert_assigned_task(connection, project_id, goal_id, "agent_researcher", "Run failing Claude CLI adapter")
+                connection.commit()
+            finally:
+                connection.close()
+
+            artifact_name = "existing-claude-artifact.txt"
+            artifact_full_path = os.path.join(tmpdir, ".maas", "artifacts", artifact_name)
+            with open(artifact_full_path, "w", encoding="utf-8") as handle:
+                handle.write("preexisting claude artifact")
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                with self.assertRaises(RuntimeError):
+                    with mock.patch(
+                        "maas.services.provider_runtime.subprocess.run",
+                        return_value=mock.Mock(returncode=1, stdout="", stderr="claude exploded"),
+                    ):
+                        run_provider_task(
+                            connection,
+                            project_paths=project_paths(tmpdir),
+                            project_id=project_id,
+                            agent_id="agent_researcher",
+                            task_id=task_id,
+                            provider_type="claude_code",
+                            artifact_path=artifact_name,
+                        )
+            finally:
+                connection.close()
+
+            self.assertTrue(os.path.exists(artifact_full_path))
+            with open(artifact_full_path, "r", encoding="utf-8") as handle:
+                self.assertEqual(handle.read(), "preexisting claude artifact")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Done on main
- [x] Timed-out session auto-retry for stale sessions
- [x] First-class quarantine queue with restore and dismiss actions
- [x] Scheduler-driven retry backoff and recover-and-requeue gating
- [x] Shared provider lifecycle contract for Python Script, Claude Code, and OpenAI Codex
- [x] Real local OpenAI Codex CLI integration behind explicit provider config

## Working in this PR
- [x] Add the real local Claude Code CLI path for claude_code
- [x] Keep simulated execution as the default unless project.yaml provider config enables Claude CLI mode
- [x] Surface configured Claude execution mode through /api/providers
- [x] Add mocked Claude CLI success and failure rollback coverage in the provider runtime suite
- [x] Sync merged-status docs so main reflects the already-shipped Codex CLI integration

## Still to do
- [ ] Broader provider runtime controls and guardrails beyond the first Claude and Codex CLI paths
- [ ] Decide whether provider settings should become first-class UI-editable project configuration
- [ ] Broader automated restart and multi-provider recovery orchestration