### PR TITLE
Add provider run controls

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -16,7 +16,7 @@ from maas.services.escalations import approve_escalation, fetch_escalations, rej
 from maas.services.failure_memory import fetch_failure_log, fetch_quarantine_queue
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
 from maas.services.live import build_live_snapshot, sse_stream
-from maas.services.provider_runtime import list_provider_runtime_status, run_provider_task
+from maas.services.provider_runtime import provider_runtime_overview, run_provider_task
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 from maas.services.security import fetch_task_capabilities
 from maas.services.steering import (
@@ -336,7 +336,7 @@ def create_app(project_root="."):
         try:
             project = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()
             project_id = project["project_id"] if project else None
-            return {"providers": list_provider_runtime_status(connection=connection, project_id=project_id)}
+            return provider_runtime_overview(connection=connection, project_id=project_id)
         finally:
             connection.close()
 

--- a/src/maas/providers.py
+++ b/src/maas/providers.py
@@ -346,6 +346,62 @@ def _provider_run_history(connection, project_id):
     return {"summaries": summaries, "recent_runs": recent_runs}
 
 
+def _provider_run_targets(connection, project_id, limit=5):
+    if connection is None:
+        return []
+
+    if project_id is None:
+        project = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()
+        project_id = project["project_id"] if project else None
+    if project_id is None:
+        return []
+
+    rows = connection.execute(
+        """
+        SELECT
+            tasks.project_id,
+            tasks.task_id,
+            tasks.title,
+            tasks.status,
+            tasks.priority,
+            tasks.review_state,
+            tasks.assigned_agent_id AS agent_id,
+            agents.display_name AS agent_name,
+            goals.title AS goal_title
+        FROM tasks
+        JOIN agents ON agents.agent_id = tasks.assigned_agent_id
+        LEFT JOIN goals ON goals.goal_id = tasks.goal_id
+        WHERE tasks.project_id = ?
+          AND tasks.assigned_agent_id IS NOT NULL
+          AND tasks.status IN ('planned', 'ready', 'assigned')
+          AND (
+              tasks.next_retry_at IS NULL
+              OR datetime(tasks.next_retry_at) <= CURRENT_TIMESTAMP
+          )
+          AND EXISTS (
+              SELECT 1
+              FROM task_capability_grants grants
+              WHERE grants.project_id = tasks.project_id
+                AND grants.task_id = tasks.task_id
+                AND grants.agent_id = tasks.assigned_agent_id
+                AND grants.capability = 'execute'
+                AND grants.revoked_at IS NULL
+          )
+        ORDER BY tasks.priority DESC, tasks.created_at ASC
+        LIMIT ?
+        """,
+        (project_id, limit),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def fetch_provider_runtime_overview(connection=None, project_id=None):
+    return {
+        "providers": list_provider_status(connection=connection, project_id=project_id),
+        "run_targets": _provider_run_targets(connection, project_id),
+    }
+
+
 def get_provider_status(provider_id, connection=None, project_id=None):
     provider = get_provider(provider_id)
     provider_config = _project_provider_config(connection, project_id)

--- a/src/maas/services/provider_runtime.py
+++ b/src/maas/services/provider_runtime.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import tempfile
 
-from maas.providers import get_provider_runtime_settings, list_provider_status
+from maas.providers import fetch_provider_runtime_overview, get_provider_runtime_settings, list_provider_status
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
 
 
@@ -470,3 +470,7 @@ def run_provider_task(connection, project_paths, project_id, agent_id, task_id, 
 
 def list_provider_runtime_status(connection=None, project_id=None):
     return list_provider_status(connection=connection, project_id=project_id)
+
+
+def provider_runtime_overview(connection=None, project_id=None):
+    return fetch_provider_runtime_overview(connection=connection, project_id=project_id)

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -129,6 +129,11 @@ class ProviderRuntimeTest(unittest.TestCase):
             self.assertEqual(providers["claude_code"]["recent_runs"], [])
             self.assertEqual(providers["openai_codex"]["recent_runs"], [])
             self.assertGreaterEqual(len(providers["python_script"]["recent_runs"]), 1)
+            self.assertTrue(all("task_id" in target for target in payload["run_targets"]))
+            self.assertTrue(all("agent_id" in target for target in payload["run_targets"]))
+            self.assertTrue(
+                all(target["status"] in ("planned", "ready", "assigned") for target in payload["run_targets"])
+            )
 
     def test_providers_endpoint_reflects_configured_openai_codex_cli_mode(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -446,6 +451,50 @@ class ProviderRuntimeTest(unittest.TestCase):
             providers = {provider["id"]: provider for provider in providers_payload["providers"]}
             self.assertEqual(providers["python_script"]["run_summary"]["completed_runs"], 4)
             self.assertEqual(len(providers["python_script"]["recent_runs"]), 3)
+
+    def test_providers_endpoint_includes_manual_run_targets_with_execute_grants(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Provider Runtime Test", description="Provider runtime test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                goal_id = connection.execute("SELECT goal_id FROM goals ORDER BY created_at ASC LIMIT 1").fetchone()["goal_id"]
+                runnable_task_id = _insert_assigned_task(
+                    connection,
+                    project_id,
+                    goal_id,
+                    "agent_allocator",
+                    "Run provider-target task",
+                )
+                blocked_task_id = generate_id("task")
+                connection.execute(
+                    """
+                    INSERT INTO tasks (
+                        task_id, project_id, goal_id, title, description, status, priority, assigned_agent_id, acceptance_criteria_json, next_retry_at
+                    ) VALUES (?, ?, ?, ?, '', 'assigned', 65, ?, '[]', datetime('now', '+10 minutes'))
+                    """,
+                    (blocked_task_id, project_id, goal_id, "Skip cooldown task", "agent_allocator"),
+                )
+                no_grant_task_id = generate_id("task")
+                connection.execute(
+                    """
+                    INSERT INTO tasks (
+                        task_id, project_id, goal_id, title, description, status, priority, assigned_agent_id, acceptance_criteria_json
+                    ) VALUES (?, ?, ?, ?, '', 'assigned', 60, ?, '[]')
+                    """,
+                    (no_grant_task_id, project_id, goal_id, "Skip no-grant task", "agent_allocator"),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            payload = client.get("/api/providers").json()
+            run_target_ids = {target["task_id"] for target in payload["run_targets"]}
+
+            self.assertIn(runnable_task_id, run_target_ids)
+            self.assertNotIn(blocked_task_id, run_target_ids)
+            self.assertNotIn(no_grant_task_id, run_target_ids)
 
     def test_lifecycle_start_rejects_unknown_provider(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -290,7 +290,8 @@ const PROVIDERS_FALLBACK: ProvidersResponse = {
       recent_runs: [],
       notes: "Simulated API-style adapter with normalized runtime phase reporting."
     }
-  ]
+  ],
+  run_targets: []
 };
 
 async function fetchJson<T>(path: string, fallback: T): Promise<T> {
@@ -369,6 +370,23 @@ export function fetchLiveSnapshot() {
 
 export function fetchProviders() {
   return fetchJson<ProvidersResponse>("/api/providers", PROVIDERS_FALLBACK);
+}
+
+export async function runProviderTask(providerId: string, projectId: string, agentId: string, taskId: string) {
+  const payload = await postJson<{
+    session_id: string;
+    artifact_id?: string | null;
+    artifact_path: string;
+  }>(`/api/providers/${providerId}/actions/run-task`, {
+    project_id: projectId,
+    agent_id: agentId,
+    task_id: taskId
+  });
+  return payload as {
+    session_id: string;
+    artifact_id?: string | null;
+    artifact_path: string;
+  };
 }
 
 async function postJson<T>(path: string, body: Record<string, string | number | null | undefined>): Promise<T | null> {

--- a/web/src/pages/ProvidersPage.tsx
+++ b/web/src/pages/ProvidersPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { StatCard } from "../components/StatCard";
-import { fetchProviders } from "../lib/controlRoomApi";
+import { fetchProviders, runProviderTask } from "../lib/controlRoomApi";
 import { useLivePulse } from "../lib/useLivePulse";
-import type { ProviderStatusItem, ProvidersResponse } from "../types";
+import type { ProviderRunTarget, ProviderStatusItem, ProvidersResponse } from "../types";
 
 function formatRuntimeControls(provider: ProviderStatusItem) {
   const controls = provider.runtime_controls ?? {};
@@ -28,6 +28,8 @@ function formatRuntimeControls(provider: ProviderStatusItem) {
 
 export function ProvidersPage() {
   const [providers, setProviders] = useState<ProvidersResponse | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [pendingRun, setPendingRun] = useState<string | null>(null);
   const livePulse = useLivePulse();
 
   useEffect(() => {
@@ -51,6 +53,26 @@ export function ProvidersPage() {
   const simulatedCount = items.filter((provider) => provider.configured_execution_mode === "local_simulation").length;
   const misconfiguredCount = items.filter((provider) => provider.status === "misconfigured").length;
   const totalRuns = items.reduce((sum, provider) => sum + (provider.run_summary?.total_runs ?? 0), 0);
+  const runTargets = providers?.run_targets ?? [];
+
+  async function reloadProviders() {
+    setProviders(await fetchProviders());
+  }
+
+  async function handleRunTask(providerId: string, target: ProviderRunTarget) {
+    const actionKey = `${providerId}:${target.task_id}`;
+    setPendingRun(actionKey);
+    setNotice(null);
+    try {
+      const payload = await runProviderTask(providerId, target.project_id, target.agent_id, target.task_id);
+      await reloadProviders();
+      setNotice(`Started ${providerId} run for ${target.title}. Session ${payload.session_id} completed and recorded a provider artifact.`);
+    } catch {
+      setNotice(`Provider run failed for ${target.title}; the task remains under operator review.`);
+    } finally {
+      setPendingRun(null);
+    }
+  }
 
   return (
     <section className="control-page">
@@ -60,6 +82,7 @@ export function ProvidersPage() {
           <h1>Runtime providers and execution modes</h1>
           <p>See which adapters are simulated, which local CLI paths are enabled, and whether any provider config is blocking execution.</p>
         </div>
+        {notice ? <p className="filters-panel__notice">{notice}</p> : null}
       </header>
 
       <section className="stats-grid">
@@ -71,6 +94,47 @@ export function ProvidersPage() {
       </section>
 
       <section className="overview-grid">
+        <article className="data-panel">
+          <header className="data-panel__header">
+            <div>
+              <h2>Manual provider runs</h2>
+              <p>Only tasks with an assigned agent, active execute grant, and no retry cooldown are shown here.</p>
+            </div>
+          </header>
+          <div className="data-list">
+            {runTargets.map((target) => (
+              <div key={target.task_id} className="data-list__item">
+                <div>
+                  <strong>{target.title}</strong>
+                  <p>
+                    {target.goal_title ?? "Unlinked goal"} | {target.agent_name ?? target.agent_id}
+                  </p>
+                  <p>
+                    Status: {target.status} | Priority: {target.priority}
+                    {target.review_state ? ` | ${target.review_state}` : ""}
+                  </p>
+                </div>
+                <div className="data-list__meta">
+                  {items.map((provider) => {
+                    const actionKey = `${provider.id}:${target.task_id}`;
+                    return (
+                      <button
+                        key={provider.id}
+                        type="button"
+                        className="task-action task-action--secondary"
+                        disabled={!provider.is_runnable || pendingRun === actionKey}
+                        onClick={() => void handleRunTask(provider.id, target)}
+                      >
+                        {pendingRun === actionKey ? "Running..." : `Run ${provider.name}`}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+
         <article className="data-panel">
           <header className="data-panel__header">
             <div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -358,6 +358,18 @@ export interface ProviderRunItem {
   ended_at?: string | null;
 }
 
+export interface ProviderRunTarget {
+  project_id: string;
+  task_id: string;
+  title: string;
+  status: "planned" | "ready" | "assigned";
+  priority: number;
+  review_state?: string | null;
+  agent_id: string;
+  agent_name?: string | null;
+  goal_title?: string | null;
+}
+
 export interface ProviderStatusItem {
   id: string;
   name: string;
@@ -382,6 +394,7 @@ export interface ProviderStatusItem {
 
 export interface ProvidersResponse {
   providers: ProviderStatusItem[];
+  run_targets: ProviderRunTarget[];
 }
 
 export interface LiveSnapshot {


### PR DESCRIPTION
## Done on main
- [x] /api/providers exposes provider status, config warnings, runtime controls, and recent run history
- [x] The control room has a Providers view
- [x] The backend already supports POST /api/providers/{provider_id}/actions/run-task

## Working in this PR
- [ ] Add bounded manual run targets to the provider overview payload
- [ ] Let operators launch safe assigned tasks directly from the Providers page using the existing run-task endpoint
- [ ] Keep manual run targets limited to tasks with an assigned agent, active execute grant, and no retry cooldown

## Still to do after this PR
- [ ] Broader provider coverage beyond the current local CLI paths
- [ ] Richer provider execution controls and policy editing from the UI
- [ ] Credentialed or network-backed provider integrations

## Validation
- PYTHONPATH=src python3 -m py_compile src/maas/providers.py src/maas/services/provider_runtime.py src/maas/api.py tests/test_provider_runtime.py
- PYTHONPATH=src python3 -m unittest tests.test_provider_runtime
- git diff --check
