### PR TITLE
Resolve auto-retried failure alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Legend:
 - [x] Escalation queue for risky steering approvals
 - [x] Failure-memory logging, quarantine visibility, repeated-failure alerts, incident-specific alert actions, and task recovery for failure-blocked work
 - [x] Manual recover-and-requeue for failure-blocked tasks
-- [x] Timed-out session auto-retry with tracked retry state
+- [x] Timed-out and failed-session auto-retry with tracked retry state
 - [x] Quarantine queue workflow with restore and dismiss actions
 - [x] Recovery for agents left in `error`
 - [x] Real local Claude Code CLI integration behind explicit provider config
@@ -137,7 +137,7 @@ These commands expose the current dependency-aware ready queue, allocator flow, 
 - quarantined failure artifacts are isolated under `.maas/quarantine/` and surfaced through the failure-memory reads
 - first-class quarantine queue reads and actions now track open, restored, and dismissed artifact incidents
 - operators can return failure-blocked tasks to the planning queue without resuming the old execution context
-- timed-out sessions can auto-retry under project recovery policy with tracked retry state
+- timed-out and failed sessions can auto-retry under project recovery policy with tracked retry state
 - operators can recover timeout-stranded agents from `error` back to `idle` once no active session remains
 
 ## Provider Notes

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -21,7 +21,7 @@ Legend for the checklist column:
 | 4. Greenfield onboarding | `[x]` | `maas init`, generated workspace, seeded backlog, project-understanding artifact |
 | 5. Supervisor, dashboard, and Kanban V1 | `[ ]` | Board API, board UI, control-room views, supervisor loop, ready refresh, idle-agent allocation, overview/roster operator controls, and board/overview/goal tree/failure/provider reads |
 | 6. Security and human steering | `[ ]` | Review, reprioritize, reassign, pause/resume, halt actions with audit logging, board controls, role-baseline gating, task-scoped execution grants, and escalation queue approvals |
-| 7. Resilience and failure memory | `[ ]` | Stale-session detection, failure logging for failed/timed-out sessions, timed-out session auto-retry, quarantine queue restore/dismiss workflows, repeated-failure alerts, read-model visibility, and task plus agent recovery exist; broader recovery is still pending |
+| 7. Resilience and failure memory | `[ ]` | Stale-session detection, failure logging for failed/timed-out sessions, timed-out and failed-session auto-retry, quarantine queue restore/dismiss workflows, repeated-failure alerts, read-model visibility, and task plus agent recovery exist; broader recovery is still pending |
 | 8. Brownfield and multi-project | `[ ]` | Still roadmap only |
 
 ## Delivery Order

--- a/docs/implementation/07-resilience-and-failure-memory.md
+++ b/docs/implementation/07-resilience-and-failure-memory.md
@@ -16,6 +16,7 @@
 - [x] Failed and timed-out session artifacts are isolated under `.maas/quarantine/`
 - [x] Quarantine details are visible in failure reads and overview failure surfaces
 - [x] Timed-out sessions can auto-retry under project recovery policy
+- [x] Failed sessions can auto-retry under project recovery policy
 - [x] A first-class quarantine queue exposes open, restored, and dismissed incidents
 - [x] Operators can resolve repeated-failure incidents from the Alerts view without changing task state
 - [x] Operators can recover failure-blocked tasks

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -68,6 +68,7 @@
 - [x] Stale-session detection in the supervisor pass
 - [x] Failure-memory logging for failed and timed-out sessions
 - [x] Timed-out session auto-retry with retry state surfaced in task and failure reads
+- [x] Failed-session auto-retry with retry state surfaced in task and failure reads
 - [x] Repeated-failure alerts for tasks with repeated failures
 - [x] Failure visibility in board, overview, live, and dedicated failures reads
 - [x] Quarantine details are visible in recent failure reads and the control-room failure surfaces

--- a/src/maas/services/alerts.py
+++ b/src/maas/services/alerts.py
@@ -164,7 +164,14 @@ def _resolve_alerts_by_query(connection, query, params, project_id, actor_id, re
     return resolved_alert_ids
 
 
-def resolve_task_session_failed_alerts(connection, project_id, task_id, actor_id, reason):
+def resolve_task_session_failed_alerts(
+    connection,
+    project_id,
+    task_id,
+    actor_id,
+    reason,
+    activity_description="Task failure alerts resolved after task recovery.",
+):
     return _resolve_alerts_by_query(
         connection,
         """
@@ -182,7 +189,7 @@ def resolve_task_session_failed_alerts(connection, project_id, task_id, actor_id
         reason,
         task_id,
         "task_failure_alert_resolved",
-        "Task failure alerts resolved after task recovery.",
+        activity_description,
     )
 
 

--- a/src/maas/services/lifecycle.py
+++ b/src/maas/services/lifecycle.py
@@ -4,6 +4,7 @@ import json
 
 from maas.ids import generate_id
 from maas.providers import get_provider
+from maas.services.alerts import resolve_task_session_failed_alerts
 from maas.services.recovery_policy import (
     failed_session_retry_cooldown_seconds,
     fetch_project_recovery_policy,
@@ -409,6 +410,15 @@ def end_session(connection, session_id, outcome, summary, project_paths=None):
                 WHERE task_id = ? AND status = 'in_progress'
                 """,
                 (row["task_id"],),
+            )
+        else:
+            resolve_task_session_failed_alerts(
+                connection,
+                row["project_id"],
+                row["task_id"],
+                row["agent_id"],
+                reason="task_auto_retried",
+                activity_description="Task failure alerts resolved after automatic task retry.",
             )
     elif outcome == "cancelled":
         record_failure(

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -16,6 +16,24 @@ from maas.services.live import build_live_snapshot
 
 
 class AlertsAndLiveApiTest(unittest.TestCase):
+    def _update_recovery_config(self, project_root, **recovery_updates):
+        connection = connect(project_paths(project_root))
+        try:
+            project = connection.execute(
+                "SELECT project_id, config_json FROM projects LIMIT 1"
+            ).fetchone()
+            config = json.loads(project["config_json"] or "{}")
+            recovery = dict(config.get("recovery") or {})
+            recovery.update(recovery_updates)
+            config["recovery"] = recovery
+            connection.execute(
+                "UPDATE projects SET config_json = ? WHERE project_id = ?",
+                (json.dumps(config), project["project_id"]),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
     def test_alert_actions_and_live_snapshot(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Live Test", description="Live test", project_type="custom")
@@ -121,6 +139,50 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             self.assertEqual(recent_failure["failure_type"], "session_failed")
             self.assertEqual(recent_failure["quarantined_artifact_count"], 1)
             self.assertEqual(recent_failure["quarantined_artifacts"][0]["quarantined_from_path"], artifact_path)
+
+    def test_failed_session_auto_retry_resolves_task_failure_alert(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Auto Retry Alert Resolution Test",
+                description="Auto retry alert resolution test",
+                project_type="custom",
+            )
+            self._update_recovery_config(
+                tmpdir,
+                auto_retry_failed_sessions=True,
+                max_failed_session_retries=1,
+                failed_session_retry_cooldown_seconds=45,
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting auto retry alert resolution test",
+                )
+                end_session(connection, session_id, "failed", "Retryable failed session")
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            alerts_payload = client.get("/api/alerts").json()
+            matching_alerts = [
+                alert
+                for alert in alerts_payload["alerts"]
+                if alert["title"] == "Task session failed"
+            ]
+
+            self.assertEqual(len(matching_alerts), 1)
+            self.assertEqual(matching_alerts[0]["status"], "resolved")
+            self.assertNotIn("operator_action", matching_alerts[0])
 
     def test_quarantine_api_lists_open_entries_for_failed_sessions(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -294,6 +294,15 @@ class LifecycleStateTransitionTest(unittest.TestCase):
                     """,
                     (task_id,),
                 ).fetchone()
+                alert = connection.execute(
+                    """
+                    SELECT status
+                    FROM alerts
+                    WHERE title = 'Task session failed'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
             finally:
                 connection.close()
 
@@ -308,6 +317,7 @@ class LifecycleStateTransitionTest(unittest.TestCase):
             self.assertIn("Retryable lifecycle failure", failure["summary"])
             self.assertIsNotNone(auto_retry_audit)
             self.assertEqual(json.loads(auto_retry_audit["detail_json"])["failure_type"], "session_failed")
+            self.assertEqual(alert["status"], "resolved")
 
     def test_failed_session_stays_blocked_when_failed_retry_budget_is_exhausted(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -357,6 +367,15 @@ class LifecycleStateTransitionTest(unittest.TestCase):
                     """,
                     (task_id,),
                 ).fetchone()
+                alert = connection.execute(
+                    """
+                    SELECT status
+                    FROM alerts
+                    WHERE title = 'Task session failed'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
             finally:
                 connection.close()
 
@@ -366,6 +385,7 @@ class LifecycleStateTransitionTest(unittest.TestCase):
             self.assertEqual(task["last_retry_reason"], "session_failed")
             self.assertIsNone(task["next_retry_at"])
             self.assertIsNone(task["next_retry_reason"])
+            self.assertEqual(alert["status"], "open")
 
     def test_failed_session_quarantines_session_artifacts(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Done on main
- [x] Provider status, mode switching, and editable provider settings are shipped and reflected in the original roadmap/status docs
- [x] Timed-out and failed-session auto-retry both exist with tracked retry state and cooldown/backoff support
- [x] Failed-session incidents already write failure memory, quarantine artifacts, and open Task session failed alerts

## Working in this PR
- [ ] Resolve Task session failed alerts automatically when a failed session is immediately auto-retried
- [ ] Keep failure memory, quarantine, and the resolved alert record intact so the incident is still auditable without staying open
- [ ] Add lifecycle and alerts API regressions to prove auto-retried failures no longer surface as open actionable alerts
- [ ] Sync the original docs to the newly merged failed-session auto-retry state on main

## Still to do after this PR
- [ ] Broader scheduler-driven recovery and requeue policies
- [ ] Broader DLQ/quarantine and self-healing workflows
- [ ] Broader external provider coverage beyond the current local CLI paths
- [ ] Brownfield and multi-project support

## Validation
- PYTHONPATH=src python3 -m py_compile src/maas/services/alerts.py src/maas/services/lifecycle.py tests/test_lifecycle.py tests/test_alerts_live_api.py
- PYTHONPATH=src python3 -m unittest tests.test_lifecycle
- PYTHONPATH=src python3 -m unittest tests.test_alerts_live_api
- git diff --check
