### PR TITLE
Add quarantine restore and requeue flow

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -27,6 +27,7 @@ from maas.services.steering import (
     reassign_task,
     recover_agent,
     recover_task,
+    restore_and_requeue_quarantine_entry,
     restore_quarantine_entry,
     restore_failure_artifacts,
     resolve_task_repeated_failures,
@@ -321,6 +322,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return restore_quarantine_entry(connection, paths, queue_id, payload.actor_id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/quarantine/{queue_id}/actions/restore-and-requeue")
+    def quarantine_restore_and_requeue_action(queue_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return restore_and_requeue_quarantine_entry(connection, paths, queue_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -21,6 +21,7 @@ from maas.services.steering import (
     recover_and_requeue_task,
     recover_task,
     resolve_task_repeated_failures,
+    restore_and_requeue_quarantine_entry,
     restore_quarantine_entry,
     restore_failure_artifacts,
 )
@@ -118,6 +119,11 @@ def build_parser():
     quarantine_restore_parser.add_argument("--project-root", default=".")
     quarantine_restore_parser.add_argument("--queue-id", required=True)
     quarantine_restore_parser.add_argument("--actor-id", required=True)
+
+    quarantine_restore_and_requeue_parser = quarantine_subparsers.add_parser("restore-and-requeue")
+    quarantine_restore_and_requeue_parser.add_argument("--project-root", default=".")
+    quarantine_restore_and_requeue_parser.add_argument("--queue-id", required=True)
+    quarantine_restore_and_requeue_parser.add_argument("--actor-id", required=True)
 
     quarantine_dismiss_parser = quarantine_subparsers.add_parser("dismiss")
     quarantine_dismiss_parser.add_argument("--project-root", default=".")
@@ -312,6 +318,8 @@ def command_quarantine(args):
             print(json.dumps(fetch_quarantine_queue(connection, limit=args.limit), indent=2))
         elif args.quarantine_command == "restore":
             print(json.dumps(restore_quarantine_entry(connection, paths, args.queue_id, args.actor_id), indent=2))
+        elif args.quarantine_command == "restore-and-requeue":
+            print(json.dumps(restore_and_requeue_quarantine_entry(connection, paths, args.queue_id, args.actor_id), indent=2))
         elif args.quarantine_command == "dismiss":
             print(json.dumps(dismiss_quarantine_entry(connection, args.queue_id, args.actor_id), indent=2))
     finally:

--- a/src/maas/services/failure_memory.py
+++ b/src/maas/services/failure_memory.py
@@ -684,6 +684,8 @@ def fetch_quarantine_queue(connection, limit=20):
             failure_log.failure_type,
             failure_log.summary,
             tasks.title AS task_title,
+            tasks.status AS task_status,
+            tasks.review_state AS task_review_state,
             agents.display_name AS agent_name
         FROM quarantine_queue
         LEFT JOIN failure_log ON failure_log.failure_id = quarantine_queue.failure_id

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -199,8 +199,20 @@ def recover_task(connection, task_id, actor_id):
 
 def recover_and_requeue_task(connection, task_id, actor_id):
     task = _load_recoverable_task(connection, task_id, actor_id)
+    refreshed_task = _recover_and_requeue_task(connection, task, actor_id)
+    connection.commit()
+    return {
+        "task_id": task_id,
+        "status": refreshed_task["status"],
+        "review_state": refreshed_task["review_state"],
+        "next_retry_at": refreshed_task["next_retry_at"],
+        "next_retry_reason": refreshed_task["next_retry_reason"],
+    }
+
+
+def _recover_and_requeue_task(connection, task, actor_id):
     recovery_policy = fetch_project_recovery_policy(connection, task["project_id"])
-    failure_count = failure_attempt_count(connection, task_id)
+    failure_count = failure_attempt_count(connection, task["task_id"])
     cooldown_seconds = recover_and_requeue_cooldown_seconds(recovery_policy, failure_count)
     next_retry_at = retry_deadline(cooldown_seconds)
     next_retry_reason = "recover_and_requeue" if next_retry_at is not None else None
@@ -218,23 +230,15 @@ def recover_and_requeue_task(connection, task_id, actor_id):
             "cooldown_seconds": cooldown_seconds,
         },
     )
-    refresh_ready_tasks(connection)
-    refreshed_task = connection.execute(
+    refresh_ready_tasks(connection, commit=False)
+    return connection.execute(
         """
         SELECT status, review_state, next_retry_at, next_retry_reason
         FROM tasks
         WHERE task_id = ?
         """,
-        (task_id,),
+        (task["task_id"],),
     ).fetchone()
-    connection.commit()
-    return {
-        "task_id": task_id,
-        "status": refreshed_task["status"],
-        "review_state": refreshed_task["review_state"],
-        "next_retry_at": refreshed_task["next_retry_at"],
-        "next_retry_reason": refreshed_task["next_retry_reason"],
-    }
 
 
 def _load_recoverable_task(connection, task_id, actor_id):
@@ -439,6 +443,47 @@ def restore_quarantine_entry(connection, project_paths, queue_id, actor_id):
         "restored_artifacts": restored_artifacts,
         "restored_count": len(restored_artifacts),
         "status": "restored",
+    }
+
+
+def restore_and_requeue_quarantine_entry(connection, project_paths, queue_id, actor_id):
+    queue_entry = connection.execute(
+        """
+        SELECT queue_id, project_id, task_id, session_id, status
+        FROM quarantine_queue
+        WHERE queue_id = ?
+        """,
+        (queue_id,),
+    ).fetchone()
+    if queue_entry is None:
+        raise ValueError("Quarantine entry not found")
+    if queue_entry["status"] != "open":
+        raise ValueError("Only open quarantine entries can be restored and requeued")
+    if queue_entry["task_id"] is None:
+        raise ValueError("Quarantine entry is not linked to a recoverable task")
+
+    task = _load_recoverable_task(connection, queue_entry["task_id"], actor_id)
+    restored_artifacts = _restore_quarantine_session(
+        connection,
+        project_paths,
+        queue_entry,
+        actor_id,
+        resource_type="quarantine",
+        resource_id=queue_id,
+    )
+    refreshed_task = _recover_and_requeue_task(connection, task, actor_id)
+    connection.commit()
+    return {
+        "queue_id": queue_id,
+        "task_id": task["task_id"],
+        "session_id": queue_entry["session_id"],
+        "restored_artifacts": restored_artifacts,
+        "restored_count": len(restored_artifacts),
+        "status": "restored",
+        "task_status": refreshed_task["status"],
+        "task_review_state": refreshed_task["review_state"],
+        "next_retry_at": refreshed_task["next_retry_at"],
+        "next_retry_reason": refreshed_task["next_retry_reason"],
     }
 
 

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -437,6 +437,163 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             self.assertIsNotNone(queue_row["resolved_at"])
             self.assertTrue(os.path.exists(artifact_path))
 
+    def test_quarantine_restore_and_requeue_action_restores_files_and_requeues_task(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Quarantine Restore Requeue API Test",
+                description="Quarantine restore requeue api test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting quarantine restore requeue api test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "quarantine-restore-requeue-note.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("restore and requeue queue entry\n")
+                artifact_id = produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with queue restore and requeue coverage",
+                    project_paths=result["paths"],
+                )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            queue_entry = client.get("/api/quarantine").json()["entries"][0]
+            restore_response = client.post(
+                "/api/quarantine/{0}/actions/restore-and-requeue".format(queue_entry["queue_id"]),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(restore_response.status_code, 200)
+            self.assertEqual(restore_response.json()["status"], "restored")
+            self.assertEqual(restore_response.json()["restored_count"], 1)
+            self.assertEqual(restore_response.json()["task_id"], task_id)
+            self.assertEqual(restore_response.json()["task_status"], "planned")
+            self.assertEqual(restore_response.json()["task_review_state"], "retry_backoff")
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                artifact = connection.execute(
+                    """
+                    SELECT path, metadata_json
+                    FROM artifacts
+                    WHERE artifact_id = ?
+                    """,
+                    (artifact_id,),
+                ).fetchone()
+                task = connection.execute(
+                    """
+                    SELECT status, review_state, next_retry_at, next_retry_reason
+                    FROM tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+                queue_row = connection.execute(
+                    """
+                    SELECT status, resolved_at
+                    FROM quarantine_queue
+                    WHERE queue_id = ?
+                    """,
+                    (queue_entry["queue_id"],),
+                ).fetchone()
+            finally:
+                connection.close()
+
+            metadata = json.loads(artifact["metadata_json"] or "{}")
+            self.assertEqual(artifact["path"], artifact_path)
+            self.assertTrue(metadata["restored_from_quarantine"])
+            self.assertEqual(task["status"], "planned")
+            self.assertEqual(task["review_state"], "retry_backoff")
+            self.assertIsNotNone(task["next_retry_at"])
+            self.assertEqual(task["next_retry_reason"], "recover_and_requeue")
+            self.assertEqual(queue_row["status"], "restored")
+            self.assertIsNotNone(queue_row["resolved_at"])
+            self.assertTrue(os.path.exists(artifact_path))
+
+    def test_quarantine_restore_and_requeue_action_rejects_nonrecoverable_task(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Quarantine Restore Requeue Guard Test",
+                description="Quarantine restore requeue guard test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting quarantine restore requeue guard test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "quarantine-restore-requeue-guard.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("guard queue entry\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with queue restore and requeue guard coverage",
+                    project_paths=result["paths"],
+                )
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'ready', review_state = NULL
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            queue_entry = client.get("/api/quarantine").json()["entries"][0]
+            restore_response = client.post(
+                "/api/quarantine/{0}/actions/restore-and-requeue".format(queue_entry["queue_id"]),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(restore_response.status_code, 400)
+            self.assertIn("recover", restore_response.json()["detail"])
+
     def test_restore_failure_artifacts_action_restores_quarantined_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -11,6 +11,7 @@ import type {
   OverviewResponse,
   ProvidersResponse,
   QuarantineQueueResponse,
+  RestoreAndRequeueQuarantineEntryResponse,
   RestoreFailureArtifactsResponse,
   RestoreQuarantineEntryResponse,
   SupervisorRunResponse
@@ -368,6 +369,16 @@ export async function restoreQuarantineEntry(queueId: string) {
     actor_id: "agent_allocator"
   });
   return payload as RestoreQuarantineEntryResponse;
+}
+
+export async function restoreAndRequeueQuarantineEntry(queueId: string) {
+  const payload = await postJson<RestoreAndRequeueQuarantineEntryResponse>(
+    `/api/quarantine/${queueId}/actions/restore-and-requeue`,
+    {
+      actor_id: "agent_allocator"
+    }
+  );
+  return payload as RestoreAndRequeueQuarantineEntryResponse;
 }
 
 export async function dismissQuarantineEntry(queueId: string) {

--- a/web/src/pages/FailuresPage.tsx
+++ b/web/src/pages/FailuresPage.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { dismissQuarantineEntry, fetchFailures, fetchQuarantineQueue, restoreQuarantineEntry } from "../lib/controlRoomApi";
+import {
+  dismissQuarantineEntry,
+  fetchFailures,
+  fetchQuarantineQueue,
+  restoreAndRequeueQuarantineEntry,
+  restoreQuarantineEntry
+} from "../lib/controlRoomApi";
 import { useLivePulse } from "../lib/useLivePulse";
 import type { FailuresResponse, QuarantineQueueResponse } from "../types";
 import { StatCard } from "../components/StatCard";
@@ -57,6 +63,22 @@ export function FailuresPage() {
       setNotice(`Dismissed quarantine entry ${queueId}; artifacts remain isolated.`);
     } catch {
       setNotice("Quarantine dismissal failed; leave the entry open for operator review.");
+    } finally {
+      setPendingQueueAction(null);
+    }
+  }
+
+  async function handleRestoreAndRequeue(queueId: string) {
+    setPendingQueueAction(`restore-and-requeue:${queueId}`);
+    setNotice(null);
+    try {
+      const payload = await restoreAndRequeueQuarantineEntry(queueId);
+      await reload();
+      setNotice(
+        `Restored ${payload.restored_count} quarantined artifact(s) and returned task ${payload.task_id} to ${payload.task_status}.`
+      );
+    } catch {
+      setNotice("Restore and requeue failed; keep the quarantine entry under operator review.");
     } finally {
       setPendingQueueAction(null);
     }
@@ -143,6 +165,12 @@ export function FailuresPage() {
                     Status: {item.status} | Artifacts: {item.artifact_count}
                     {item.reason ? ` | Reason: ${item.reason}` : ""}
                   </p>
+                  {item.task_status ? (
+                    <p>
+                      Task: {item.task_status}
+                      {item.task_review_state ? ` | ${item.task_review_state}` : ""}
+                    </p>
+                  ) : null}
                   {item.quarantined_artifacts?.[0]?.quarantined_from_path ? (
                     <p>Original path: {item.quarantined_artifacts[0].quarantined_from_path}</p>
                   ) : null}
@@ -150,11 +178,28 @@ export function FailuresPage() {
                 <div className="data-list__meta">
                   <span>{item.failure_type ?? "quarantine"}</span>
                   <span>{new Date(item.created_at).toLocaleString()}</span>
+                  {item.status === "open" &&
+                  item.task_status === "blocked" &&
+                  (item.task_review_state === "session_failed" || item.task_review_state === "stale_session") ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--secondary"
+                      disabled={pendingQueueAction === `restore-and-requeue:${item.queue_id}`}
+                      onClick={() => void handleRestoreAndRequeue(item.queue_id)}
+                    >
+                      {pendingQueueAction === `restore-and-requeue:${item.queue_id}`
+                        ? "Restoring..."
+                        : "Restore + requeue"}
+                    </button>
+                  ) : null}
                   {item.status === "open" ? (
                     <button
                       type="button"
                       className="task-action task-action--secondary"
-                      disabled={pendingQueueAction === `restore:${item.queue_id}`}
+                      disabled={
+                        pendingQueueAction === `restore:${item.queue_id}` ||
+                        pendingQueueAction === `restore-and-requeue:${item.queue_id}`
+                      }
                       onClick={() => void handleRestore(item.queue_id)}
                     >
                       {pendingQueueAction === `restore:${item.queue_id}` ? "Restoring..." : "Restore"}
@@ -164,7 +209,10 @@ export function FailuresPage() {
                     <button
                       type="button"
                       className="task-action"
-                      disabled={pendingQueueAction === `dismiss:${item.queue_id}`}
+                      disabled={
+                        pendingQueueAction === `dismiss:${item.queue_id}` ||
+                        pendingQueueAction === `restore-and-requeue:${item.queue_id}`
+                      }
                       onClick={() => void handleDismiss(item.queue_id)}
                     >
                       {pendingQueueAction === `dismiss:${item.queue_id}` ? "Dismissing..." : "Dismiss"}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -176,6 +176,8 @@ export interface QuarantineQueueItem {
   failure_id?: string | null;
   task_id?: string | null;
   task_title?: string | null;
+  task_status?: string | null;
+  task_review_state?: string | null;
   agent_name?: string | null;
   failure_type?: string | null;
   summary?: string | null;
@@ -228,6 +230,19 @@ export interface RestoreQuarantineEntryResponse {
   restored_artifacts: QuarantinedArtifactItem[];
   restored_count: number;
   status: "restored";
+}
+
+export interface RestoreAndRequeueQuarantineEntryResponse {
+  queue_id: string;
+  task_id: string;
+  session_id: string;
+  restored_artifacts: QuarantinedArtifactItem[];
+  restored_count: number;
+  status: "restored";
+  task_status: string;
+  task_review_state?: string | null;
+  next_retry_at?: string | null;
+  next_retry_reason?: string | null;
 }
 
 export interface DismissQuarantineEntryResponse {


### PR DESCRIPTION
## Done on main
- [x] Quarantine queue supports restore and dismiss actions
- [x] Failed and timed-out sessions already land in quarantine with failure visibility and recover/requeue controls elsewhere in the control room
- [x] Timed-out and failed-session auto-retry flows are in place with tracked retry state

## Working in this PR
- [ ] Add a combined quarantine queue action to restore artifacts and recover-and-requeue the linked task in one step
- [ ] Keep the combined flow atomic by validating recoverability first, then restoring artifacts and requeueing inside one transaction
- [ ] Expose the action through API, CLI, and the Failures page
- [ ] Only show the new button for open queue entries linked to recoverable blocked tasks
- [ ] Add API regressions for the happy path and the nonrecoverable-task guardrail

## Still to do after this PR
- [ ] Broader scheduler-driven recovery and requeue policies
- [ ] Broader DLQ/quarantine and self-healing workflows
- [ ] Broader external provider coverage beyond the current local CLI paths
- [ ] Brownfield and multi-project support

## Validation
- PYTHONPATH=src python3 -m py_compile src/maas/services/steering.py src/maas/services/failure_memory.py src/maas/api.py src/maas/cli.py tests/test_alerts_live_api.py tests/test_api_board_actions.py
- PYTHONPATH=src python3 -m unittest tests.test_alerts_live_api
- PYTHONPATH=src python3 -m unittest tests.test_api_board_actions
- git diff --check
