### PR TITLE
Add operator actions to recent failure rows

### DIFF
--- a/src/maas/services/failure_memory.py
+++ b/src/maas/services/failure_memory.py
@@ -10,6 +10,7 @@ from maas.ids import generate_id
 
 REPEATED_FAILURE_THRESHOLD = 2
 REPEATED_FAILURE_TYPES = ("session_failed", "session_timed_out", "capability_denied")
+RECOVERABLE_FAILURE_REVIEW_STATES = ("session_failed", "stale_session")
 
 
 def record_failure(connection, project_id, failure_type, summary, task_id=None, session_id=None, agent_id=None, details=None):
@@ -649,15 +650,91 @@ def _quarantined_artifacts_by_session(connection, session_ids):
     return artifacts_by_session
 
 
+def _quarantine_queue_entries_by_session(connection, session_ids):
+    if not session_ids:
+        return {}
+
+    placeholders = ", ".join(["?"] * len(session_ids))
+    rows = connection.execute(
+        """
+        SELECT session_id, queue_id, status
+        FROM quarantine_queue
+        WHERE session_id IN ({0})
+        ORDER BY
+            CASE status
+                WHEN 'open' THEN 0
+                WHEN 'dismissed' THEN 1
+                ELSE 2
+            END,
+            created_at DESC
+        """.format(placeholders),
+        tuple(session_ids),
+    ).fetchall()
+
+    queue_entries = {}
+    for row in rows:
+        queue_entries.setdefault(row["session_id"], dict(row))
+    return queue_entries
+
+
+def _failure_has_recoverable_task(failure):
+    return failure.get("task_status") == "blocked" and failure.get("task_review_state") in RECOVERABLE_FAILURE_REVIEW_STATES
+
+
+def _infer_failure_operator_action(failure):
+    queue_id = failure.get("quarantine_queue_id")
+    queue_status = failure.get("quarantine_queue_status")
+
+    if queue_id and queue_status == "open" and _failure_has_recoverable_task(failure):
+        return {
+            "action": "restore_and_requeue_quarantine_entry",
+            "label": "Restore + requeue",
+            "resource_type": "quarantine",
+            "resource_id": queue_id,
+            "related_task_id": failure.get("task_id"),
+        }
+
+    if (
+        failure.get("failure_id")
+        and queue_status == "open"
+        and failure.get("quarantined_artifact_count", 0) > 0
+    ):
+        return {
+            "action": "restore_failure_artifacts",
+            "label": "Restore artifacts",
+            "resource_type": "failure",
+            "resource_id": failure["failure_id"],
+            "related_task_id": failure.get("task_id"),
+        }
+
+    if failure.get("task_id") and _failure_has_recoverable_task(failure):
+        return {
+            "action": "recover_and_requeue_task",
+            "label": "Recover + requeue",
+            "resource_type": "task",
+            "resource_id": failure["task_id"],
+        }
+
+    return None
+
+
 def enrich_failures_with_quarantine(connection, failures):
     session_ids = [failure["session_id"] for failure in failures if failure.get("session_id")]
     artifacts_by_session = _quarantined_artifacts_by_session(connection, session_ids)
+    queue_entries_by_session = _quarantine_queue_entries_by_session(connection, session_ids)
     enriched = []
     for failure in failures:
         quarantined_artifacts = artifacts_by_session.get(failure.get("session_id"), [])
+        queue_entry = queue_entries_by_session.get(failure.get("session_id"))
         enriched_failure = dict(failure)
         enriched_failure["quarantined_artifacts"] = quarantined_artifacts
         enriched_failure["quarantined_artifact_count"] = len(quarantined_artifacts)
+        if queue_entry is not None:
+            enriched_failure["quarantine_queue_id"] = queue_entry["queue_id"]
+            enriched_failure["quarantine_queue_status"] = queue_entry["status"]
+        operator_action = _infer_failure_operator_action(enriched_failure)
+        if operator_action is not None:
+            enriched_failure["operator_action"] = operator_action
         enriched.append(enriched_failure)
     return enriched
 
@@ -741,6 +818,8 @@ def fetch_failure_log(connection, limit=20):
             failure_log.detail_json,
             failure_log.created_at,
             tasks.title AS task_title,
+            tasks.status AS task_status,
+            tasks.review_state AS task_review_state,
             tasks.retry_count,
             tasks.last_retry_at,
             tasks.last_retry_reason,

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -140,6 +140,176 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             self.assertEqual(recent_failure["quarantined_artifact_count"], 1)
             self.assertEqual(recent_failure["quarantined_artifacts"][0]["quarantined_from_path"], artifact_path)
 
+    def test_failures_api_prefers_restore_and_requeue_for_recoverable_quarantined_failures(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Failure Operator Action Queue Test",
+                description="Failure operator action queue test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting failure operator action queue test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "failure-operator-action-queue.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("queue action\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with recoverable quarantined artifacts",
+                    project_paths=result["paths"],
+                )
+                queue_id = connection.execute(
+                    "SELECT queue_id FROM quarantine_queue WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()["queue_id"]
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recent_failure = client.get("/api/failures").json()["recent"][0]
+
+            self.assertEqual(
+                recent_failure["operator_action"],
+                {
+                    "action": "restore_and_requeue_quarantine_entry",
+                    "label": "Restore + requeue",
+                    "resource_type": "quarantine",
+                    "resource_id": queue_id,
+                    "related_task_id": task_id,
+                },
+            )
+
+    def test_failures_api_uses_recover_and_requeue_for_recoverable_nonquarantined_failures(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(
+                tmpdir,
+                name="Failure Operator Action Recover Test",
+                description="Failure operator action recover test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting failure operator action recover test",
+                )
+                end_session(connection, session_id, "failed", "Failure without artifacts")
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recent_failure = client.get("/api/failures").json()["recent"][0]
+
+            self.assertEqual(
+                recent_failure["operator_action"],
+                {
+                    "action": "recover_and_requeue_task",
+                    "label": "Recover + requeue",
+                    "resource_type": "task",
+                    "resource_id": task_id,
+                },
+            )
+
+    def test_failures_api_uses_restore_for_open_quarantine_when_task_is_not_recoverable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Failure Operator Action Restore Test",
+                description="Failure operator action restore test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting failure operator action restore test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "failure-operator-action-restore.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("restore action\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with open quarantine but nonrecoverable task state",
+                    project_paths=result["paths"],
+                )
+                failure_id = connection.execute(
+                    "SELECT failure_id FROM failure_log WHERE session_id = ? ORDER BY created_at DESC LIMIT 1",
+                    (session_id,),
+                ).fetchone()["failure_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET review_state = 'blocked_by_dependency'
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recent_failure = client.get("/api/failures").json()["recent"][0]
+
+            self.assertEqual(
+                recent_failure["operator_action"],
+                {
+                    "action": "restore_failure_artifacts",
+                    "label": "Restore artifacts",
+                    "resource_type": "failure",
+                    "resource_id": failure_id,
+                    "related_task_id": task_id,
+                },
+            )
+
     def test_failed_session_auto_retry_resolves_task_failure_alert(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -5,6 +5,7 @@ import type {
   AlertsResponse,
   DismissQuarantineEntryResponse,
   EscalationsResponse,
+  FailureOperatorAction,
   FailuresResponse,
   GoalTreeResponse,
   LiveSnapshot,
@@ -388,6 +389,13 @@ export async function dismissQuarantineEntry(queueId: string) {
   return payload as DismissQuarantineEntryResponse;
 }
 
+export async function recoverAndRequeueTask(taskId: string) {
+  const payload = await postJson(`/api/tasks/${taskId}/actions/recover-and-requeue`, {
+    actor_id: "agent_allocator"
+  });
+  return payload;
+}
+
 export function fetchLiveSnapshot() {
   return fetchJson<LiveSnapshot>("/api/live", LIVE_FALLBACK);
 }
@@ -468,6 +476,18 @@ export async function runAlertOperatorAction(operatorAction: AlertOperatorAction
     return;
   }
   await postJson(`/api/agents/${operatorAction.resource_id}/actions/recover`, { actor_id: "agent_allocator" });
+}
+
+export async function runFailureOperatorAction(operatorAction: FailureOperatorAction) {
+  if (operatorAction.action === "restore_and_requeue_quarantine_entry") {
+    await restoreAndRequeueQuarantineEntry(operatorAction.resource_id);
+    return;
+  }
+  if (operatorAction.action === "restore_failure_artifacts") {
+    await restoreFailureArtifacts(operatorAction.resource_id);
+    return;
+  }
+  await recoverAndRequeueTask(operatorAction.resource_id);
 }
 
 export async function updateEscalationStatus(escalationId: string, action: "approve" | "reject", resolutionNote = "") {

--- a/web/src/pages/FailuresPage.tsx
+++ b/web/src/pages/FailuresPage.tsx
@@ -3,6 +3,7 @@ import {
   dismissQuarantineEntry,
   fetchFailures,
   fetchQuarantineQueue,
+  runFailureOperatorAction,
   restoreAndRequeueQuarantineEntry,
   restoreQuarantineEntry
 } from "../lib/controlRoomApi";
@@ -13,6 +14,7 @@ import { StatCard } from "../components/StatCard";
 export function FailuresPage() {
   const [failures, setFailures] = useState<FailuresResponse | null>(null);
   const [quarantineQueue, setQuarantineQueue] = useState<QuarantineQueueResponse | null>(null);
+  const [pendingFailureAction, setPendingFailureAction] = useState<string | null>(null);
   const [pendingQueueAction, setPendingQueueAction] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const livePulse = useLivePulse();
@@ -84,6 +86,31 @@ export function FailuresPage() {
     }
   }
 
+  async function handleRecentFailureAction(failureId: string) {
+    const failure = failures?.recent.find((item) => item.failure_id === failureId);
+    if (!failure?.operator_action) {
+      return;
+    }
+
+    setPendingFailureAction(`${failureId}:${failure.operator_action.action}`);
+    setNotice(null);
+    try {
+      await runFailureOperatorAction(failure.operator_action);
+      await reload();
+      if (failure.operator_action.action === "restore_and_requeue_quarantine_entry") {
+        setNotice(`Restored quarantined artifacts and returned task ${failure.operator_action.related_task_id} to the queue.`);
+      } else if (failure.operator_action.action === "restore_failure_artifacts") {
+        setNotice(`Restored quarantined artifacts for failure ${failureId}.`);
+      } else {
+        setNotice(`Recovered and requeued task ${failure.operator_action.resource_id}.`);
+      }
+    } catch {
+      setNotice("Failure action failed; keep the incident under operator review.");
+    } finally {
+      setPendingFailureAction(null);
+    }
+  }
+
   return (
     <section className="control-page">
       <header className="page-hero">
@@ -142,6 +169,22 @@ export function FailuresPage() {
                 <div className="data-list__meta">
                   <span>{item.failure_type}</span>
                   <span>{new Date(item.created_at).toLocaleString()}</span>
+                  {item.operator_action ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--approve"
+                      disabled={pendingFailureAction === `${item.failure_id}:${item.operator_action.action}`}
+                      onClick={() => item.failure_id && void handleRecentFailureAction(item.failure_id)}
+                    >
+                      {pendingFailureAction === `${item.failure_id}:${item.operator_action.action}`
+                        ? item.operator_action.action === "restore_and_requeue_quarantine_entry"
+                          ? "Restoring..."
+                          : item.operator_action.action === "restore_failure_artifacts"
+                            ? "Restoring..."
+                            : "Recovering..."
+                        : item.operator_action.label}
+                    </button>
+                  ) : null}
                 </div>
               </div>
             ))}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -160,7 +160,16 @@ export interface FailureItem {
   detail_json?: string;
   quarantined_artifact_count?: number;
   quarantined_artifacts?: QuarantinedArtifactItem[];
+  operator_action?: FailureOperatorAction;
   created_at: string;
+}
+
+export interface FailureOperatorAction {
+  action: "recover_and_requeue_task" | "restore_failure_artifacts" | "restore_and_requeue_quarantine_entry";
+  label: string;
+  resource_type: "task" | "failure" | "quarantine";
+  resource_id: string;
+  related_task_id?: string | null;
 }
 
 export interface QuarantinedArtifactItem {


### PR DESCRIPTION
## Done on main
- [x] Failure memory, quarantine queue, and quarantine restore/requeue flows exist
- [x] Failures view shows recent failures, repeated-failure tasks, and quarantine queue workflow
- [x] Alerts already expose operator actions for recoverable task, agent, and repeated-failure cases

## Working in this PR
- [x] Add a single primary `operator_action` to recent `/api/failures` rows based on current task/quarantine state
- [x] Prefer `Restore + requeue` for recoverable quarantined failures, then `Restore artifacts`, then `Recover + requeue`
- [x] Wire the Failures page to run those existing actions directly from recent failure rows
- [x] Add focused API regressions for each action shape

## Still to do
- [ ] Broader failure-memory operator workflows beyond the current recent-failure and quarantine actions
- [ ] More autonomous recovery policies beyond timeout and failed-session retry paths
- [ ] Brownfield and multi-project roadmap work
