### PR TITLE
Add quarantine reopen workflow

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -27,6 +27,7 @@ from maas.services.steering import (
     reassign_task,
     recover_agent,
     recover_task,
+    reopen_quarantine_entry,
     restore_and_requeue_quarantine_entry,
     restore_quarantine_entry,
     restore_failure_artifacts,
@@ -346,6 +347,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return dismiss_quarantine_entry(connection, queue_id, payload.actor_id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/quarantine/{queue_id}/actions/reopen")
+    def quarantine_reopen_action(queue_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return reopen_quarantine_entry(connection, queue_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -17,6 +17,7 @@ from maas.services.lifecycle import end_session, heartbeat, log_activity, produc
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 from maas.services.steering import (
     dismiss_quarantine_entry,
+    reopen_quarantine_entry,
     recover_agent,
     recover_and_requeue_task,
     recover_task,
@@ -129,6 +130,11 @@ def build_parser():
     quarantine_dismiss_parser.add_argument("--project-root", default=".")
     quarantine_dismiss_parser.add_argument("--queue-id", required=True)
     quarantine_dismiss_parser.add_argument("--actor-id", required=True)
+
+    quarantine_reopen_parser = quarantine_subparsers.add_parser("reopen")
+    quarantine_reopen_parser.add_argument("--project-root", default=".")
+    quarantine_reopen_parser.add_argument("--queue-id", required=True)
+    quarantine_reopen_parser.add_argument("--actor-id", required=True)
 
     escalation_parser = subparsers.add_parser("escalation")
     escalation_subparsers = escalation_parser.add_subparsers(dest="escalation_command", required=True)
@@ -322,6 +328,8 @@ def command_quarantine(args):
             print(json.dumps(restore_and_requeue_quarantine_entry(connection, paths, args.queue_id, args.actor_id), indent=2))
         elif args.quarantine_command == "dismiss":
             print(json.dumps(dismiss_quarantine_entry(connection, args.queue_id, args.actor_id), indent=2))
+        elif args.quarantine_command == "reopen":
+            print(json.dumps(reopen_quarantine_entry(connection, args.queue_id, args.actor_id), indent=2))
     finally:
         connection.close()
 

--- a/src/maas/services/failure_memory.py
+++ b/src/maas/services/failure_memory.py
@@ -433,6 +433,25 @@ def dismiss_quarantine_queue_entry(connection, queue_id):
     return dict(entry)
 
 
+def reopen_quarantine_queue_entry(connection, queue_id):
+    backfill_quarantine_queue(connection)
+    entry = connection.execute(
+        """
+        SELECT queue_id, project_id, session_id, task_id, failure_id, status, artifact_count
+        FROM quarantine_queue
+        WHERE queue_id = ?
+        """,
+        (queue_id,),
+    ).fetchone()
+    if entry is None:
+        raise ValueError("Quarantine entry not found")
+    if entry["status"] != "dismissed":
+        raise ValueError("Only dismissed quarantine entries can be reopened")
+
+    _set_quarantine_queue_status_for_session(connection, entry["session_id"], "open", "")
+    return dict(entry)
+
+
 def _repeated_failure_clause():
     placeholders = ", ".join(["?"] * len(REPEATED_FAILURE_TYPES))
     return "failure_type IN ({0})".format(placeholders), REPEATED_FAILURE_TYPES

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -13,6 +13,7 @@ from maas.services.alerts import resolve_stale_heartbeat_alerts, resolve_task_se
 from maas.services.failure_memory import (
     failure_attempt_count,
     dismiss_quarantine_queue_entry,
+    reopen_quarantine_queue_entry,
     resolve_repeated_failure_alerts,
     restore_quarantined_session_artifacts,
 )
@@ -571,6 +572,54 @@ def dismiss_quarantine_entry(connection, queue_id, actor_id):
         "session_id": dismissed_entry["session_id"],
         "status": "dismissed",
         "artifact_count": dismissed_entry["artifact_count"],
+    }
+
+
+def reopen_quarantine_entry(connection, queue_id, actor_id):
+    queue_entry = connection.execute(
+        """
+        SELECT queue_id, project_id, task_id, session_id, status, artifact_count
+        FROM quarantine_queue
+        WHERE queue_id = ?
+        """,
+        (queue_id,),
+    ).fetchone()
+    if queue_entry is None:
+        raise ValueError("Quarantine entry not found")
+    ensure_board_action_allowed(
+        connection,
+        actor_id,
+        queue_entry["project_id"],
+        "reopen_quarantine_entry",
+        "quarantine",
+        queue_id,
+    )
+    reopened_entry = reopen_quarantine_queue_entry(connection, queue_id)
+
+    _audit(
+        connection,
+        queue_entry["project_id"],
+        actor_id,
+        "reopen_quarantine_entry",
+        "quarantine",
+        queue_id,
+        {"session_id": queue_entry["session_id"], "artifact_count": queue_entry["artifact_count"]},
+    )
+    _activity(
+        connection,
+        queue_entry["project_id"],
+        actor_id,
+        queue_entry["task_id"],
+        "quarantine_reopened",
+        "Dismissed quarantined artifacts returned to the open review queue.",
+        severity="warning",
+    )
+    connection.commit()
+    return {
+        "queue_id": queue_id,
+        "session_id": reopened_entry["session_id"],
+        "status": "open",
+        "artifact_count": reopened_entry["artifact_count"],
     }
 
 

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -1066,6 +1066,162 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             self.assertTrue(os.path.exists(artifact["path"]))
             self.assertFalse(os.path.exists(artifact_path))
 
+    def test_quarantine_reopen_action_returns_dismissed_entry_to_open(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Quarantine Reopen API Test",
+                description="Quarantine reopen api test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting quarantine reopen api test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "quarantine-reopen-note.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("reopen queue entry\n")
+                artifact_id = produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with queue reopen coverage",
+                    project_paths=result["paths"],
+                )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            queue_entry = client.get("/api/quarantine").json()["entries"][0]
+            dismiss_response = client.post(
+                "/api/quarantine/{0}/actions/dismiss".format(queue_entry["queue_id"]),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(dismiss_response.status_code, 200)
+
+            reopen_response = client.post(
+                "/api/quarantine/{0}/actions/reopen".format(queue_entry["queue_id"]),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(reopen_response.status_code, 200)
+            self.assertEqual(reopen_response.json()["status"], "open")
+
+            queue_payload = client.get("/api/quarantine").json()
+            reopened_entry = [entry for entry in queue_payload["entries"] if entry["queue_id"] == queue_entry["queue_id"]][0]
+            self.assertEqual(reopened_entry["status"], "open")
+            self.assertEqual(queue_payload["summary"]["open"], 1)
+            self.assertEqual(queue_payload["summary"]["dismissed"], 0)
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                artifact = connection.execute(
+                    """
+                    SELECT path, metadata_json
+                    FROM artifacts
+                    WHERE artifact_id = ?
+                    """,
+                    (artifact_id,),
+                ).fetchone()
+                queue_row = connection.execute(
+                    """
+                    SELECT status, resolution_note, resolved_at
+                    FROM quarantine_queue
+                    WHERE queue_id = ?
+                    """,
+                    (queue_entry["queue_id"],),
+                ).fetchone()
+                reopen_activity = connection.execute(
+                    """
+                    SELECT action
+                    FROM activity_log
+                    WHERE task_id = ? AND action = 'quarantine_reopened'
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+            finally:
+                connection.close()
+
+            metadata = json.loads(artifact["metadata_json"] or "{}")
+            self.assertTrue(metadata["quarantined"])
+            self.assertEqual(queue_row["status"], "open")
+            self.assertEqual(queue_row["resolution_note"], "")
+            self.assertIsNone(queue_row["resolved_at"])
+            self.assertEqual(reopen_activity["action"], "quarantine_reopened")
+            self.assertTrue(os.path.exists(artifact["path"]))
+            self.assertFalse(os.path.exists(artifact_path))
+
+    def test_quarantine_reopen_action_rejects_nondismissed_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Quarantine Reopen Guard Test",
+                description="Quarantine reopen guard test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting quarantine reopen guard test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "quarantine-reopen-guard-note.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("open queue entry\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with queue reopen guard coverage",
+                    project_paths=result["paths"],
+                )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            queue_entry = client.get("/api/quarantine").json()["entries"][0]
+            reopen_response = client.post(
+                "/api/quarantine/{0}/actions/reopen".format(queue_entry["queue_id"]),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(reopen_response.status_code, 400)
+            self.assertIn("dismissed", reopen_response.json()["detail"])
+
     def test_restore_failure_artifacts_action_rejects_existing_destination(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -12,6 +12,7 @@ import type {
   OverviewResponse,
   ProvidersResponse,
   QuarantineQueueResponse,
+  ReopenQuarantineEntryResponse,
   RestoreAndRequeueQuarantineEntryResponse,
   RestoreFailureArtifactsResponse,
   RestoreQuarantineEntryResponse,
@@ -387,6 +388,13 @@ export async function dismissQuarantineEntry(queueId: string) {
     actor_id: "agent_allocator"
   });
   return payload as DismissQuarantineEntryResponse;
+}
+
+export async function reopenQuarantineEntry(queueId: string) {
+  const payload = await postJson<ReopenQuarantineEntryResponse>(`/api/quarantine/${queueId}/actions/reopen`, {
+    actor_id: "agent_allocator"
+  });
+  return payload as ReopenQuarantineEntryResponse;
 }
 
 export async function recoverAndRequeueTask(taskId: string) {

--- a/web/src/pages/FailuresPage.tsx
+++ b/web/src/pages/FailuresPage.tsx
@@ -4,6 +4,7 @@ import {
   fetchFailures,
   fetchQuarantineQueue,
   runAlertOperatorAction,
+  reopenQuarantineEntry,
   runFailureOperatorAction,
   restoreAndRequeueQuarantineEntry,
   restoreQuarantineEntry
@@ -67,6 +68,20 @@ export function FailuresPage() {
       setNotice(`Dismissed quarantine entry ${queueId}; artifacts remain isolated.`);
     } catch {
       setNotice("Quarantine dismissal failed; leave the entry open for operator review.");
+    } finally {
+      setPendingQueueAction(null);
+    }
+  }
+
+  async function handleReopen(queueId: string) {
+    setPendingQueueAction(`reopen:${queueId}`);
+    setNotice(null);
+    try {
+      await reopenQuarantineEntry(queueId);
+      await reload();
+      setNotice(`Reopened quarantine entry ${queueId} for operator review.`);
+    } catch {
+      setNotice("Quarantine reopen failed; keep the current entry state under review.");
     } finally {
       setPendingQueueAction(null);
     }
@@ -280,6 +295,16 @@ export function FailuresPage() {
                       onClick={() => void handleDismiss(item.queue_id)}
                     >
                       {pendingQueueAction === `dismiss:${item.queue_id}` ? "Dismissing..." : "Dismiss"}
+                    </button>
+                  ) : null}
+                  {item.status === "dismissed" ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--secondary"
+                      disabled={pendingQueueAction === `reopen:${item.queue_id}`}
+                      onClick={() => void handleReopen(item.queue_id)}
+                    >
+                      {pendingQueueAction === `reopen:${item.queue_id}` ? "Reopening..." : "Reopen"}
                     </button>
                   ) : null}
                   {item.resolved_at ? <span>{new Date(item.resolved_at).toLocaleString()}</span> : null}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -262,6 +262,13 @@ export interface DismissQuarantineEntryResponse {
   artifact_count: number;
 }
 
+export interface ReopenQuarantineEntryResponse {
+  queue_id: string;
+  session_id: string;
+  status: "open";
+  artifact_count: number;
+}
+
 export interface GoalTreeNode {
   goal_id: string;
   parent_goal_id?: string | null;


### PR DESCRIPTION
## Done on main
- [x] Failure memory, quarantine queue, and restore/requeue/dismiss flows exist
- [x] Failures view surfaces recent failures, quarantine queue entries, and recovery-linked operator actions
- [x] Quarantine dismiss keeps artifacts isolated but removes the incident from the open queue

## Working in this PR
- [x] Add a `reopen` action for dismissed quarantine entries so operators can return them to the open review queue
- [x] Expose the reopen workflow through backend service, API, and CLI paths
- [x] Surface `Reopen` for dismissed entries in the Failures page
- [x] Add focused regressions for reopen success and guardrails

## Still to do
- [ ] Broader DLQ and quarantine workflows beyond the current open/restore/dismiss/reopen paths
- [ ] More autonomous recovery orchestration beyond the current retry and manual operator flows
- [ ] Brownfield and multi-project roadmap work
