### PR TITLE
Add reopen action to recent failures

### DIFF
--- a/src/maas/services/failure_memory.py
+++ b/src/maas/services/failure_memory.py
@@ -758,6 +758,19 @@ def _infer_failure_operator_action(failure):
         }
 
     if (
+        queue_id
+        and queue_status == "dismissed"
+        and failure.get("quarantined_artifact_count", 0) > 0
+    ):
+        return {
+            "action": "reopen_quarantine_entry",
+            "label": "Reopen",
+            "resource_type": "quarantine",
+            "resource_id": queue_id,
+            "related_task_id": failure.get("task_id"),
+        }
+
+    if (
         failure.get("failure_id")
         and queue_status == "open"
         and failure.get("quarantined_artifact_count", 0) > 0

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -310,6 +310,76 @@ class AlertsAndLiveApiTest(unittest.TestCase):
                 },
             )
 
+    def test_failures_api_uses_reopen_for_dismissed_quarantine_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Failure Operator Action Reopen Test",
+                description="Failure operator action reopen test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting failure operator action reopen test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "failure-operator-action-reopen.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("reopen action\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Failure with dismissed quarantine entry",
+                    project_paths=result["paths"],
+                )
+                queue_id = connection.execute(
+                    "SELECT queue_id FROM quarantine_queue WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()["queue_id"]
+                connection.execute(
+                    """
+                    UPDATE quarantine_queue
+                    SET status = 'dismissed', resolution_note = 'quarantine_dismissed', resolved_at = CURRENT_TIMESTAMP
+                    WHERE queue_id = ?
+                    """,
+                    (queue_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recent_failure = client.get("/api/failures").json()["recent"][0]
+
+            self.assertEqual(
+                recent_failure["operator_action"],
+                {
+                    "action": "reopen_quarantine_entry",
+                    "label": "Reopen",
+                    "resource_type": "quarantine",
+                    "resource_id": queue_id,
+                    "related_task_id": task_id,
+                },
+            )
+
     def test_failures_api_exposes_repeated_failure_operator_action_when_alert_is_open(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -491,6 +491,10 @@ export async function runFailureOperatorAction(operatorAction: FailureOperatorAc
     await restoreAndRequeueQuarantineEntry(operatorAction.resource_id);
     return;
   }
+  if (operatorAction.action === "reopen_quarantine_entry") {
+    await reopenQuarantineEntry(operatorAction.resource_id);
+    return;
+  }
   if (operatorAction.action === "restore_failure_artifacts") {
     await restoreFailureArtifacts(operatorAction.resource_id);
     return;

--- a/web/src/pages/FailuresPage.tsx
+++ b/web/src/pages/FailuresPage.tsx
@@ -116,6 +116,8 @@ export function FailuresPage() {
       await reload();
       if (failure.operator_action.action === "restore_and_requeue_quarantine_entry") {
         setNotice(`Restored quarantined artifacts and returned task ${failure.operator_action.related_task_id} to the queue.`);
+      } else if (failure.operator_action.action === "reopen_quarantine_entry") {
+        setNotice(`Reopened dismissed quarantine entry for failure ${failureId}.`);
       } else if (failure.operator_action.action === "restore_failure_artifacts") {
         setNotice(`Restored quarantined artifacts for failure ${failureId}.`);
       } else {
@@ -215,6 +217,8 @@ export function FailuresPage() {
                       {pendingFailureAction === `${item.failure_id}:${item.operator_action.action}`
                         ? item.operator_action.action === "restore_and_requeue_quarantine_entry"
                           ? "Restoring..."
+                          : item.operator_action.action === "reopen_quarantine_entry"
+                            ? "Reopening..."
                           : item.operator_action.action === "restore_failure_artifacts"
                             ? "Restoring..."
                             : "Recovering..."

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -165,7 +165,11 @@ export interface FailureItem {
 }
 
 export interface FailureOperatorAction {
-  action: "recover_and_requeue_task" | "restore_failure_artifacts" | "restore_and_requeue_quarantine_entry";
+  action:
+    | "recover_and_requeue_task"
+    | "restore_failure_artifacts"
+    | "restore_and_requeue_quarantine_entry"
+    | "reopen_quarantine_entry";
   label: string;
   resource_type: "task" | "failure" | "quarantine";
   resource_id: string;


### PR DESCRIPTION
## Done on main
- [x] Failures view surfaces recent failures, repeated-failure tasks, and quarantine queue workflows
- [x] Quarantine entries can now be restored, dismissed, requeued, and reopened from the queue itself
- [x] Recent failure rows already expose recovery and quarantine restore actions for open incidents

## Working in this PR
- [x] Add `Reopen` as a recent-failure operator action when the linked quarantine incident is currently dismissed
- [x] Reuse the existing quarantine reopen backend path instead of introducing a second workflow
- [x] Surface the new action directly in the Recent failures section
- [x] Add focused API coverage for the dismissed-quarantine action shape

## Still to do
- [ ] Broader DLQ and quarantine workflows beyond the current open/restore/dismiss/reopen paths
- [ ] More autonomous recovery orchestration beyond the current retry and manual operator flows
- [ ] Brownfield and multi-project roadmap work
