### PR TITLE
Add dismiss action to recent failures

### DIFF
--- a/src/maas/services/failure_memory.py
+++ b/src/maas/services/failure_memory.py
@@ -794,6 +794,26 @@ def _infer_failure_operator_action(failure):
     return None
 
 
+def _infer_failure_secondary_operator_action(failure):
+    queue_id = failure.get("quarantine_queue_id")
+    queue_status = failure.get("quarantine_queue_status")
+
+    if (
+        queue_id
+        and queue_status == "open"
+        and failure.get("quarantined_artifact_count", 0) > 0
+    ):
+        return {
+            "action": "dismiss_quarantine_entry",
+            "label": "Dismiss",
+            "resource_type": "quarantine",
+            "resource_id": queue_id,
+            "related_task_id": failure.get("task_id"),
+        }
+
+    return None
+
+
 def enrich_failures_with_quarantine(connection, failures):
     session_ids = [failure["session_id"] for failure in failures if failure.get("session_id")]
     artifacts_by_session = _quarantined_artifacts_by_session(connection, session_ids)
@@ -811,6 +831,9 @@ def enrich_failures_with_quarantine(connection, failures):
         operator_action = _infer_failure_operator_action(enriched_failure)
         if operator_action is not None:
             enriched_failure["operator_action"] = operator_action
+        secondary_operator_action = _infer_failure_secondary_operator_action(enriched_failure)
+        if secondary_operator_action is not None:
+            enriched_failure["secondary_operator_action"] = secondary_operator_action
         enriched.append(enriched_failure)
     return enriched
 

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -200,6 +200,16 @@ class AlertsAndLiveApiTest(unittest.TestCase):
                     "related_task_id": task_id,
                 },
             )
+            self.assertEqual(
+                recent_failure["secondary_operator_action"],
+                {
+                    "action": "dismiss_quarantine_entry",
+                    "label": "Dismiss",
+                    "resource_type": "quarantine",
+                    "resource_id": queue_id,
+                    "related_task_id": task_id,
+                },
+            )
 
     def test_failures_api_uses_recover_and_requeue_for_recoverable_nonquarantined_failures(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -309,6 +319,16 @@ class AlertsAndLiveApiTest(unittest.TestCase):
                     "related_task_id": task_id,
                 },
             )
+            self.assertEqual(
+                recent_failure["secondary_operator_action"],
+                {
+                    "action": "dismiss_quarantine_entry",
+                    "label": "Dismiss",
+                    "resource_type": "quarantine",
+                    "resource_id": recent_failure["quarantine_queue_id"],
+                    "related_task_id": task_id,
+                },
+            )
 
     def test_failures_api_uses_reopen_for_dismissed_quarantine_entries(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -379,6 +399,7 @@ class AlertsAndLiveApiTest(unittest.TestCase):
                     "related_task_id": task_id,
                 },
             )
+            self.assertNotIn("secondary_operator_action", recent_failure)
 
     def test_failures_api_exposes_repeated_failure_operator_action_when_alert_is_open(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -491,6 +491,10 @@ export async function runFailureOperatorAction(operatorAction: FailureOperatorAc
     await restoreAndRequeueQuarantineEntry(operatorAction.resource_id);
     return;
   }
+  if (operatorAction.action === "dismiss_quarantine_entry") {
+    await dismissQuarantineEntry(operatorAction.resource_id);
+    return;
+  }
   if (operatorAction.action === "reopen_quarantine_entry") {
     await reopenQuarantineEntry(operatorAction.resource_id);
     return;

--- a/web/src/pages/FailuresPage.tsx
+++ b/web/src/pages/FailuresPage.tsx
@@ -103,25 +103,29 @@ export function FailuresPage() {
     }
   }
 
-  async function handleRecentFailureAction(failureId: string) {
+  async function handleRecentFailureAction(failureId: string, actionKind: "primary" | "secondary" = "primary") {
     const failure = failures?.recent.find((item) => item.failure_id === failureId);
-    if (!failure?.operator_action) {
+    const operatorAction =
+      actionKind === "secondary" ? failure?.secondary_operator_action : failure?.operator_action;
+    if (!operatorAction) {
       return;
     }
 
-    setPendingFailureAction(`${failureId}:${failure.operator_action.action}`);
+    setPendingFailureAction(`${failureId}:${operatorAction.action}`);
     setNotice(null);
     try {
-      await runFailureOperatorAction(failure.operator_action);
+      await runFailureOperatorAction(operatorAction);
       await reload();
-      if (failure.operator_action.action === "restore_and_requeue_quarantine_entry") {
-        setNotice(`Restored quarantined artifacts and returned task ${failure.operator_action.related_task_id} to the queue.`);
-      } else if (failure.operator_action.action === "reopen_quarantine_entry") {
+      if (operatorAction.action === "restore_and_requeue_quarantine_entry") {
+        setNotice(`Restored quarantined artifacts and returned task ${operatorAction.related_task_id} to the queue.`);
+      } else if (operatorAction.action === "dismiss_quarantine_entry") {
+        setNotice(`Dismissed quarantine incident for failure ${failureId}; artifacts remain isolated.`);
+      } else if (operatorAction.action === "reopen_quarantine_entry") {
         setNotice(`Reopened dismissed quarantine entry for failure ${failureId}.`);
-      } else if (failure.operator_action.action === "restore_failure_artifacts") {
+      } else if (operatorAction.action === "restore_failure_artifacts") {
         setNotice(`Restored quarantined artifacts for failure ${failureId}.`);
       } else {
-        setNotice(`Recovered and requeued task ${failure.operator_action.resource_id}.`);
+        setNotice(`Recovered and requeued task ${operatorAction.resource_id}.`);
       }
     } catch {
       setNotice("Failure action failed; keep the incident under operator review.");
@@ -211,18 +215,34 @@ export function FailuresPage() {
                     <button
                       type="button"
                       className="task-action task-action--approve"
-                      disabled={pendingFailureAction === `${item.failure_id}:${item.operator_action.action}`}
-                      onClick={() => item.failure_id && void handleRecentFailureAction(item.failure_id)}
+                      disabled={pendingFailureAction?.startsWith(`${item.failure_id}:`) ?? false}
+                      onClick={() => item.failure_id && void handleRecentFailureAction(item.failure_id, "primary")}
                     >
                       {pendingFailureAction === `${item.failure_id}:${item.operator_action.action}`
                         ? item.operator_action.action === "restore_and_requeue_quarantine_entry"
                           ? "Restoring..."
+                          : item.operator_action.action === "dismiss_quarantine_entry"
+                            ? "Dismissing..."
                           : item.operator_action.action === "reopen_quarantine_entry"
                             ? "Reopening..."
                           : item.operator_action.action === "restore_failure_artifacts"
                             ? "Restoring..."
                             : "Recovering..."
                         : item.operator_action.label}
+                    </button>
+                  ) : null}
+                  {item.secondary_operator_action ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--secondary"
+                      disabled={pendingFailureAction?.startsWith(`${item.failure_id}:`) ?? false}
+                      onClick={() => item.failure_id && void handleRecentFailureAction(item.failure_id, "secondary")}
+                    >
+                      {pendingFailureAction === `${item.failure_id}:${item.secondary_operator_action.action}`
+                        ? item.secondary_operator_action.action === "dismiss_quarantine_entry"
+                          ? "Dismissing..."
+                          : item.secondary_operator_action.label
+                        : item.secondary_operator_action.label}
                     </button>
                   ) : null}
                 </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -161,6 +161,7 @@ export interface FailureItem {
   quarantined_artifact_count?: number;
   quarantined_artifacts?: QuarantinedArtifactItem[];
   operator_action?: FailureOperatorAction;
+  secondary_operator_action?: FailureOperatorAction;
   created_at: string;
 }
 
@@ -169,6 +170,7 @@ export interface FailureOperatorAction {
     | "recover_and_requeue_task"
     | "restore_failure_artifacts"
     | "restore_and_requeue_quarantine_entry"
+    | "dismiss_quarantine_entry"
     | "reopen_quarantine_entry";
   label: string;
   resource_type: "task" | "failure" | "quarantine";


### PR DESCRIPTION
## Done on main
- [x] Recent failures already expose primary recovery and quarantine actions, including reopen for dismissed incidents
- [x] Quarantine queue entries can be restored, dismissed, requeued, and reopened from the queue itself
- [x] Repeated-failure incidents are actionable from both Alerts and Failures surfaces

## Working in this PR
- [x] Add `Dismiss` as a secondary action on recent failure rows when the linked quarantine incident is still open
- [x] Keep the existing primary action priority for recovery and restore flows
- [x] Reuse the existing quarantine dismiss backend path instead of introducing a second workflow
- [x] Add focused API regressions for the new secondary-action shape

## Still to do
- [ ] Broader DLQ and quarantine workflows beyond the current open/restore/dismiss/reopen paths
- [ ] More autonomous recovery orchestration beyond the current retry and manual operator flows
- [ ] Brownfield and multi-project roadmap work
