### PR TITLE
Add failure actions to overview page

### DIFF
--- a/src/maas/services/dashboard.py
+++ b/src/maas/services/dashboard.py
@@ -111,7 +111,9 @@ def fetch_overview(connection):
                 failure_log.failure_type,
                 failure_log.summary,
                 failure_log.created_at,
-                tasks.title AS task_title
+                tasks.title AS task_title,
+                tasks.status AS task_status,
+                tasks.review_state AS task_review_state
             FROM failure_log
             LEFT JOIN tasks ON tasks.task_id = failure_log.task_id
             ORDER BY failure_log.created_at DESC

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -148,6 +148,77 @@ class DashboardApiTest(unittest.TestCase):
             self.assertEqual(recent_failure["quarantined_artifact_count"], 1)
             self.assertEqual(recent_failure["quarantined_artifacts"][0]["quarantined_from_path"], artifact_path)
 
+    def test_overview_recent_failures_include_operator_actions_for_quarantined_work(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Dashboard Failure Actions Test",
+                description="Dashboard failure actions test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting dashboard failure actions test",
+                )
+                artifact_path = os.path.join(result["paths"].artifacts_dir, "dashboard-failure-actions-note.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("dashboard action\n")
+                produce_artifact(
+                    connection,
+                    project_id=project_id,
+                    session_id=session_id,
+                    task_id=task_id,
+                    artifact_type="note",
+                    path=artifact_path,
+                )
+                end_session(
+                    connection,
+                    session_id,
+                    "failed",
+                    "Dashboard failure with actions",
+                    project_paths=result["paths"],
+                )
+                queue_id = connection.execute(
+                    "SELECT queue_id FROM quarantine_queue WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()["queue_id"]
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            recent_failure = client.get("/api/overview").json()["recent_failures"][0]
+
+            self.assertEqual(
+                recent_failure["operator_action"],
+                {
+                    "action": "restore_and_requeue_quarantine_entry",
+                    "label": "Restore + requeue",
+                    "resource_type": "quarantine",
+                    "resource_id": queue_id,
+                    "related_task_id": task_id,
+                },
+            )
+            self.assertEqual(
+                recent_failure["secondary_operator_action"],
+                {
+                    "action": "dismiss_quarantine_entry",
+                    "label": "Dismiss",
+                    "resource_type": "quarantine",
+                    "resource_id": queue_id,
+                    "related_task_id": task_id,
+                },
+            )
+
     def test_agent_roster_is_enriched(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Roster Test", description="Roster test", project_type="custom")

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchOverview, runSupervisorPass } from "../lib/controlRoomApi";
+import { fetchOverview, runFailureOperatorAction, runSupervisorPass } from "../lib/controlRoomApi";
 import { useLivePulse } from "../lib/useLivePulse";
 import type { OverviewResponse, SupervisorRunResponse } from "../types";
 import { StatCard } from "../components/StatCard";
@@ -9,6 +9,7 @@ export function OverviewPage() {
   const [supervisorResult, setSupervisorResult] = useState<SupervisorRunResponse | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [isRunningSupervisor, setIsRunningSupervisor] = useState(false);
+  const [pendingFailureAction, setPendingFailureAction] = useState<string | null>(null);
   const livePulse = useLivePulse();
 
   useEffect(() => {
@@ -46,6 +47,40 @@ export function OverviewPage() {
       setNotice("Supervisor run failed; keeping the most recent overview snapshot.");
     } finally {
       setIsRunningSupervisor(false);
+    }
+  }
+
+  async function handleOverviewFailureAction(
+    failureId: string,
+    actionKind: "primary" | "secondary" = "primary",
+  ) {
+    const failure = overview?.recent_failures.find((item) => item.failure_id === failureId);
+    const operatorAction =
+      actionKind === "secondary" ? failure?.secondary_operator_action : failure?.operator_action;
+    if (!operatorAction) {
+      return;
+    }
+
+    setPendingFailureAction(`${failureId}:${operatorAction.action}`);
+    setNotice(null);
+    try {
+      await runFailureOperatorAction(operatorAction);
+      setOverview(await fetchOverview());
+      if (operatorAction.action === "restore_and_requeue_quarantine_entry") {
+        setNotice(`Restored quarantined artifacts and returned task ${operatorAction.related_task_id} to the queue.`);
+      } else if (operatorAction.action === "dismiss_quarantine_entry") {
+        setNotice(`Dismissed quarantine incident for failure ${failureId}; artifacts remain isolated.`);
+      } else if (operatorAction.action === "reopen_quarantine_entry") {
+        setNotice(`Reopened dismissed quarantine entry for failure ${failureId}.`);
+      } else if (operatorAction.action === "restore_failure_artifacts") {
+        setNotice(`Restored quarantined artifacts for failure ${failureId}.`);
+      } else {
+        setNotice(`Recovered and requeued task ${operatorAction.resource_id}.`);
+      }
+    } catch {
+      setNotice("Failure action failed; keep the incident under operator review.");
+    } finally {
+      setPendingFailureAction(null);
     }
   }
 
@@ -174,6 +209,40 @@ export function OverviewPage() {
                 <div className="data-list__meta">
                   <span>{item.failure_type}</span>
                   <span>{new Date(item.created_at).toLocaleTimeString()}</span>
+                  {item.operator_action ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--approve"
+                      disabled={pendingFailureAction?.startsWith(`${item.failure_id}:`) ?? false}
+                      onClick={() => item.failure_id && void handleOverviewFailureAction(item.failure_id, "primary")}
+                    >
+                      {pendingFailureAction === `${item.failure_id}:${item.operator_action.action}`
+                        ? item.operator_action.action === "restore_and_requeue_quarantine_entry"
+                          ? "Restoring..."
+                          : item.operator_action.action === "dismiss_quarantine_entry"
+                            ? "Dismissing..."
+                            : item.operator_action.action === "reopen_quarantine_entry"
+                              ? "Reopening..."
+                              : item.operator_action.action === "restore_failure_artifacts"
+                                ? "Restoring..."
+                                : "Recovering..."
+                        : item.operator_action.label}
+                    </button>
+                  ) : null}
+                  {item.secondary_operator_action ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--secondary"
+                      disabled={pendingFailureAction?.startsWith(`${item.failure_id}:`) ?? false}
+                      onClick={() => item.failure_id && void handleOverviewFailureAction(item.failure_id, "secondary")}
+                    >
+                      {pendingFailureAction === `${item.failure_id}:${item.secondary_operator_action.action}`
+                        ? item.secondary_operator_action.action === "dismiss_quarantine_entry"
+                          ? "Dismissing..."
+                          : item.secondary_operator_action.label
+                        : item.secondary_operator_action.label}
+                    </button>
+                  ) : null}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Done on main
- [x] Failures page exposes recent-failure actions, repeated-failure actions, and quarantine queue workflows
- [x] Recent failure rows already support recover/requeue, restore, reopen, and dismiss actions
- [x] Overview already includes recent failure read models with quarantine detail counts

## Working in this PR
- [x] Make Overview recent failures operational instead of read-only
- [x] Reuse the existing failure operator-action wiring from the Failures page
- [x] Extend the overview read model with the task state fields needed for correct action prioritization
- [x] Add dashboard API coverage for overview failure action payloads

## Still to do
- [ ] Broader DLQ and quarantine workflows beyond the current open/restore/dismiss/reopen paths
- [ ] More autonomous recovery orchestration beyond the current retry and manual operator flows
- [ ] Brownfield and multi-project roadmap work
