### PR TITLE
Add repeated failure actions to overview page

### DIFF
--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -219,6 +219,68 @@ class DashboardApiTest(unittest.TestCase):
                 },
             )
 
+    def test_overview_repeated_failures_include_operator_actions_when_alert_is_open(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(
+                tmpdir,
+                name="Dashboard Repeated Failure Actions Test",
+                description="Dashboard repeated failure actions test",
+                project_type="custom",
+            )
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Define project workspace contracts'"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    INSERT INTO failure_log (
+                        failure_id, project_id, task_id, failure_type, summary, detail_json
+                    ) VALUES
+                        (?, ?, ?, 'session_failed', 'First repeated failure', '{}'),
+                        (?, ?, ?, 'session_failed', 'Second repeated failure', '{}')
+                    """,
+                    (generate_id("fail"), project_id, task_id, generate_id("fail"), project_id, task_id),
+                )
+                connection.execute(
+                    """
+                    INSERT INTO alerts (
+                        alert_id, project_id, severity, title, description, status
+                    ) VALUES (
+                        ?,
+                        ?,
+                        'critical',
+                        'Repeated task failures',
+                        ?,
+                        'open'
+                    )
+                    """,
+                    (
+                        generate_id("alert"),
+                        project_id,
+                        "Task {0} (Define project workspace contracts) has failed 2 times. Latest failure: Second repeated failure".format(
+                            task_id
+                        ),
+                    ),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            repeated_failure = client.get("/api/overview").json()["repeated_failures"][0]
+
+            self.assertEqual(
+                repeated_failure["operator_action"],
+                {
+                    "action": "resolve_repeated_failures",
+                    "label": "Resolve repeated failures",
+                    "resource_type": "task",
+                    "resource_id": task_id,
+                },
+            )
+
     def test_agent_roster_is_enriched(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Roster Test", description="Roster test", project_type="custom")

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchOverview, runFailureOperatorAction, runSupervisorPass } from "../lib/controlRoomApi";
+import { fetchOverview, runAlertOperatorAction, runFailureOperatorAction, runSupervisorPass } from "../lib/controlRoomApi";
 import { useLivePulse } from "../lib/useLivePulse";
 import type { OverviewResponse, SupervisorRunResponse } from "../types";
 import { StatCard } from "../components/StatCard";
@@ -10,6 +10,7 @@ export function OverviewPage() {
   const [notice, setNotice] = useState<string | null>(null);
   const [isRunningSupervisor, setIsRunningSupervisor] = useState(false);
   const [pendingFailureAction, setPendingFailureAction] = useState<string | null>(null);
+  const [pendingRepeatedFailureAction, setPendingRepeatedFailureAction] = useState<string | null>(null);
   const livePulse = useLivePulse();
 
   useEffect(() => {
@@ -81,6 +82,25 @@ export function OverviewPage() {
       setNotice("Failure action failed; keep the incident under operator review.");
     } finally {
       setPendingFailureAction(null);
+    }
+  }
+
+  async function handleOverviewRepeatedFailureAction(taskId: string) {
+    const repeatedFailure = overview?.repeated_failures.find((item) => item.task_id === taskId);
+    if (!repeatedFailure?.operator_action) {
+      return;
+    }
+
+    setPendingRepeatedFailureAction(`${taskId}:${repeatedFailure.operator_action.action}`);
+    setNotice(null);
+    try {
+      await runAlertOperatorAction(repeatedFailure.operator_action);
+      setOverview(await fetchOverview());
+      setNotice(`Resolved the repeated-failure incident for ${taskId}.`);
+    } catch {
+      setNotice("Repeated-failure resolution failed; keep the task under operator review.");
+    } finally {
+      setPendingRepeatedFailureAction(null);
     }
   }
 
@@ -241,6 +261,41 @@ export function OverviewPage() {
                           ? "Dismissing..."
                           : item.secondary_operator_action.label
                         : item.secondary_operator_action.label}
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        <article className="data-panel">
+          <header className="data-panel__header">
+            <h2>Repeated failures</h2>
+            <p>Tasks that are still over the repeated-failure threshold and may need explicit operator triage.</p>
+          </header>
+          <div className="data-list">
+            {(overview?.repeated_failures ?? []).map((item) => (
+              <div key={item.task_id} className="data-list__item">
+                <div>
+                  <strong>{item.task_title ?? item.task_id}</strong>
+                  <p>{item.failure_count} logged failures</p>
+                </div>
+                <div className="data-list__meta">
+                  <span>{item.task_id}</span>
+                  <span>
+                    {item.latest_failure_at ? new Date(item.latest_failure_at).toLocaleTimeString() : "No timestamp"}
+                  </span>
+                  {item.operator_action ? (
+                    <button
+                      type="button"
+                      className="task-action task-action--approve"
+                      disabled={pendingRepeatedFailureAction === `${item.task_id}:${item.operator_action.action}`}
+                      onClick={() => void handleOverviewRepeatedFailureAction(item.task_id)}
+                    >
+                      {pendingRepeatedFailureAction === `${item.task_id}:${item.operator_action.action}`
+                        ? "Resolving..."
+                        : item.operator_action.label}
                     </button>
                   ) : null}
                 </div>


### PR DESCRIPTION
## Done on main
- [x] Overview recent failures are now actionable with the same recovery/quarantine flows as the Failures page
- [x] Failures page exposes recent-failure actions, repeated-failure actions, and quarantine queue workflows
- [x] Dashboard read models already include repeated-failure summaries and top repeated-failure tasks

## Working in this PR
- [x] Surface overview `repeated_failures` as a dedicated section instead of summary-only data
- [x] Run the existing repeated-failure resolve action directly from the Overview page
- [x] Add dashboard API coverage for repeated-failure operator actions in `/api/overview`

## Still to do
- [ ] Broader DLQ and quarantine workflows beyond the current open/restore/dismiss/reopen paths
- [ ] More autonomous recovery orchestration beyond the current retry and manual operator flows
- [ ] Brownfield and multi-project roadmap work
