### PR TITLE
Sync status docs after overview failure actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Legend:
 - [x] Failure-memory logging, quarantine visibility, repeated-failure alerts, incident-specific alert actions, and task recovery for failure-blocked work
 - [x] Manual recover-and-requeue for failure-blocked tasks
 - [x] Timed-out and failed-session auto-retry with tracked retry state
-- [x] Quarantine queue workflow with restore and dismiss actions
+- [x] Quarantine queue workflow with restore, dismiss, reopen, and restore+requeue actions
 - [x] Recovery for agents left in `error`
 - [x] Real local Claude Code CLI integration behind explicit provider config
 - [x] Real local OpenAI Codex CLI integration behind explicit provider config
@@ -136,6 +136,7 @@ These commands expose the current dependency-aware ready queue, allocator flow, 
 - failed and timed-out sessions are now recorded in failure memory and can raise repeated-failure alerts
 - quarantined failure artifacts are isolated under `.maas/quarantine/` and surfaced through the failure-memory reads
 - first-class quarantine queue reads and actions now track open, restored, and dismissed artifact incidents
+- recent failure and overview surfaces expose direct operator actions for recovery, restore, dismiss, reopen, and repeated-failure resolution
 - operators can return failure-blocked tasks to the planning queue without resuming the old execution context
 - timed-out and failed sessions can auto-retry under project recovery policy with tracked retry state
 - operators can recover timeout-stranded agents from `error` back to `idle` once no active session remains

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -19,9 +19,9 @@ Legend for the checklist column:
 | 2. Goal/task engine | `[ ]` | Goal records, task DAG storage, board-visible task states, dependency-aware ready refresh, acceptance evaluation, first-pass assignment |
 | 3. Runtime lifecycle and adapters | `[ ]` | Lifecycle operations, API/CLI entrypoints, provider registry, concrete simulated adapters for Python Script, Claude Code, and OpenAI Codex, plus local Claude and Codex CLI paths, provider runtime status/history reads, manual provider runs, provider mode switching, and editable provider settings |
 | 4. Greenfield onboarding | `[x]` | `maas init`, generated workspace, seeded backlog, project-understanding artifact |
-| 5. Supervisor, dashboard, and Kanban V1 | `[ ]` | Board API, board UI, control-room views, supervisor loop, ready refresh, idle-agent allocation, overview/roster operator controls, and board/overview/goal tree/failure/provider reads |
+| 5. Supervisor, dashboard, and Kanban V1 | `[ ]` | Board API, board UI, control-room views, supervisor loop, ready refresh, idle-agent allocation, overview/roster operator controls, board/overview/goal tree/failure/provider reads, and overview/failure failure-action controls |
 | 6. Security and human steering | `[ ]` | Review, reprioritize, reassign, pause/resume, halt actions with audit logging, board controls, role-baseline gating, task-scoped execution grants, and escalation queue approvals |
-| 7. Resilience and failure memory | `[ ]` | Stale-session detection, failure logging for failed/timed-out sessions, timed-out and failed-session auto-retry, quarantine queue restore/dismiss workflows, repeated-failure alerts, read-model visibility, and task plus agent recovery exist; broader recovery is still pending |
+| 7. Resilience and failure memory | `[ ]` | Stale-session detection, failure logging for failed/timed-out sessions, timed-out and failed-session auto-retry, quarantine queue restore/dismiss/reopen workflows, repeated-failure alerts, failure-action read-model visibility, and task plus agent recovery exist; broader recovery is still pending |
 | 8. Brownfield and multi-project | `[ ]` | Still roadmap only |
 
 ## Delivery Order

--- a/docs/implementation/05-supervisor-dashboard-and-kanban-v1.md
+++ b/docs/implementation/05-supervisor-dashboard-and-kanban-v1.md
@@ -16,6 +16,7 @@
 - [x] Providers view can trigger safe manual provider runs for assigned tasks
 - [x] Providers view can switch provider execution mode between simulation and available local live modes
 - [x] Providers view can edit provider runtime settings
+- [x] Overview and Failures views expose direct failure operator actions instead of remaining read-only summaries
 - [x] Current implementation includes a `cancelled` board column so halted work remains visible to operators
 
 ## Still To Do On `main`

--- a/docs/implementation/07-resilience-and-failure-memory.md
+++ b/docs/implementation/07-resilience-and-failure-memory.md
@@ -21,7 +21,8 @@
 - [x] Operators can resolve repeated-failure incidents from the Alerts view without changing task state
 - [x] Operators can recover failure-blocked tasks
 - [x] Operators can recover-and-requeue failure-blocked tasks
-- [x] Operators can restore or dismiss quarantine-queue incidents
+- [x] Operators can restore, dismiss, reopen, or restore-and-requeue quarantine-queue incidents
+- [x] Recent failure and overview surfaces expose direct failure operator actions for recover, restore, dismiss, reopen, and repeated-failure resolution
 - [x] Operators can recover agents left in `error`
 
 ## Still To Do On `main`

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -72,8 +72,9 @@
 - [x] Repeated-failure alerts for tasks with repeated failures
 - [x] Failure visibility in board, overview, live, and dedicated failures reads
 - [x] Quarantine details are visible in recent failure reads and the control-room failure surfaces
-- [x] First-class quarantine queue reads plus restore and dismiss actions
+- [x] First-class quarantine queue reads plus restore, dismiss, reopen, and restore+requeue actions
 - [x] Failure-specific operator actions for repeated-failure incidents and recovery-linked alerts
+- [x] Overview and Failures surfaces expose direct operator actions for recent failures and repeated-failure tasks
 - [x] Operator recovery for failure-blocked tasks
 - [x] Operator recover-and-requeue for failure-blocked tasks
 - [x] Operator recovery for agents left in `error`


### PR DESCRIPTION
## Done on main
- [x] Overview now exposes recent-failure and repeated-failure actions directly
- [x] Failures page exposes recent-failure actions, repeated-failure actions, and quarantine queue workflows
- [x] Quarantine incidents now support restore, dismiss, reopen, and restore+requeue actions

## Working in this PR
- [x] Sync the original status docs to the actual merged `main` state after the recent Overview and failure-surface work
- [x] Update Batch 5, Batch 7, roadmap, status, and README wording so checklists match shipped functionality

## Still to do
- [ ] Broader DLQ and quarantine workflows beyond the current open/restore/dismiss/reopen paths
- [ ] More autonomous recovery orchestration beyond the current retry and manual operator flows
- [ ] Brownfield and multi-project roadmap work
