### PR TITLE
Add websocket live transport for the control room

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -16,7 +16,7 @@ from maas.services.dashboard import fetch_agent_roster, fetch_goal_tree, fetch_o
 from maas.services.escalations import approve_escalation, fetch_escalations, reject_escalation, request_escalation
 from maas.services.failure_memory import fetch_failure_log, fetch_quarantine_queue
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
-from maas.services.live import build_live_snapshot, sse_stream
+from maas.services.live import build_live_snapshot, sse_stream, websocket_stream
 from maas.services.provider_runtime import provider_runtime_overview, run_provider_task, set_provider_mode, set_provider_settings
 from maas.services.scheduler import allocate_ready_tasks, assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 from maas.services.security import fetch_task_capabilities
@@ -189,6 +189,19 @@ def create_app(project_root="."):
             return connect(project_paths(root))
 
         return StreamingResponse(sse_stream(connection_factory), media_type="text/event-stream")
+
+    @app.websocket("/api/live/ws")
+    async def live_websocket(websocket: WebSocket):
+        root = paths.root
+
+        def connection_factory():
+            return connect(project_paths(root))
+
+        await websocket.accept()
+        try:
+            await websocket_stream(websocket.send_json, connection_factory)
+        except WebSocketDisconnect:
+            return
 
     @app.get("/api/board")
     def board(

--- a/src/maas/services/live.py
+++ b/src/maas/services/live.py
@@ -1,4 +1,4 @@
-"""Lightweight live snapshot and SSE helpers for dashboard refresh."""
+"""Lightweight live snapshot helpers for dashboard refresh."""
 
 import asyncio
 import json
@@ -54,4 +54,15 @@ async def sse_stream(connection_factory, interval_seconds=2):
             connection.close()
         yield "event: dashboard\n"
         yield "data: {0}\n\n".format(json.dumps(snapshot))
+        await asyncio.sleep(interval_seconds)
+
+
+async def websocket_stream(send_snapshot, connection_factory, interval_seconds=2):
+    while True:
+        connection = connection_factory()
+        try:
+            snapshot = build_live_snapshot(connection)
+        finally:
+            connection.close()
+        await send_snapshot(snapshot)
         await asyncio.sleep(interval_seconds)

--- a/tests/test_alerts_live_api.py
+++ b/tests/test_alerts_live_api.py
@@ -94,6 +94,19 @@ class AlertsAndLiveApiTest(unittest.TestCase):
             self.assertEqual(failures_payload["summary"]["total_failures"], 1)
             self.assertEqual(failures_payload["recent"][0]["failure_type"], "session_failed")
 
+    def test_live_websocket_stream_returns_dashboard_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Live WebSocket Test", description="Live websocket test", project_type="custom")
+            client = TestClient(create_app(tmpdir))
+
+            with client.websocket_connect("/api/live/ws") as websocket:
+                payload = websocket.receive_json()
+
+            self.assertIn("generated_at", payload)
+            self.assertIn("counts", payload)
+            self.assertIn("revision", payload)
+            self.assertIn("tasks_in_progress", payload["counts"])
+
     def test_failures_api_exposes_quarantined_artifacts_for_failed_sessions(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(tmpdir, name="Failure Quarantine API Test", description="Failure quarantine api test", project_type="custom")

--- a/web/src/lib/useLivePulse.ts
+++ b/web/src/lib/useLivePulse.ts
@@ -6,6 +6,8 @@ export function useLivePulse() {
   useEffect(() => {
     let cancelled = false;
     let source: EventSource | null = null;
+    let socket: WebSocket | null = null;
+    let timer: number | null = null;
 
     function bumpPulse() {
       if (!cancelled) {
@@ -13,22 +15,53 @@ export function useLivePulse() {
       }
     }
 
-    try {
-      source = new EventSource("/api/live/stream");
-      source.addEventListener("dashboard", bumpPulse);
-      source.onerror = () => {
-        source?.close();
-      };
-    } catch {
-      source = null;
+    function startPollingFallback() {
+      if (timer != null) {
+        return;
+      }
+      timer = window.setInterval(bumpPulse, 15000);
     }
 
-    const timer = window.setInterval(bumpPulse, 15000);
+    function startSseFallback() {
+      if (cancelled || source) {
+        return;
+      }
+      try {
+        source = new EventSource("/api/live/stream");
+        source.addEventListener("dashboard", bumpPulse);
+        source.onerror = () => {
+          source?.close();
+          source = null;
+          startPollingFallback();
+        };
+      } catch {
+        source = null;
+        startPollingFallback();
+      }
+    }
+
+    try {
+      socket = new WebSocket(`${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/api/live/ws`);
+      socket.onmessage = bumpPulse;
+      socket.onerror = () => {
+        socket?.close();
+      };
+      socket.onclose = () => {
+        socket = null;
+        startSseFallback();
+      };
+    } catch {
+      socket = null;
+      startSseFallback();
+    }
 
     return () => {
       cancelled = true;
+      socket?.close();
       source?.close();
-      window.clearInterval(timer);
+      if (timer != null) {
+        window.clearInterval(timer);
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Done on main
- [x] `/api/live` snapshot and SSE stream exist
- [x] Control-room pages refresh off the shared live pulse hook
- [x] Failure, provider, artifact, and board surfaces are all live-refreshable today

## Working in this PR
- [x] Add `/api/live/ws` as a real websocket transport for dashboard snapshots
- [x] Share the live snapshot loop between SSE and websocket delivery
- [x] Update the frontend live hook to prefer websocket, then SSE, then timer fallback
- [x] Add websocket coverage in the live API test suite

## Still to do
- [ ] Broader production transport concerns like auth/session isolation for multi-project setups
- [ ] Stronger live-channel observability and backpressure controls
- [ ] Removal of remaining page-local polling where websocket freshness is sufficient

## Validation
- `PYTHONPATH=src python3 -m py_compile src/maas/services/live.py src/maas/api.py tests/test_alerts_live_api.py`
- `PYTHONPATH=src python3 -m unittest tests.test_alerts_live_api`
- `git diff --check`

## Risks
- Frontend build was not run because local `tsc` is not installed in this checkout