### PR TITLE
Add retry backoff release action

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -29,6 +29,7 @@ from maas.services.steering import (
     reassign_task,
     recover_agent,
     recover_task,
+    release_task_retry_backoff,
     reopen_quarantine_entry,
     restore_and_requeue_quarantine_entry,
     restore_quarantine_entry,
@@ -719,6 +720,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return set_task_retry_limit(connection, task_id, payload.actor_id, payload.auto_retry_limit)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/tasks/{task_id}/actions/release-retry-backoff")
+    def task_release_retry_backoff_action(task_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return release_task_retry_backoff(connection, task_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -22,6 +22,7 @@ from maas.services.steering import (
     recover_agent,
     recover_and_requeue_task,
     recover_task,
+    release_task_retry_backoff,
     resolve_task_repeated_failures,
     set_task_retry_limit,
     restore_and_requeue_quarantine_entry,
@@ -100,6 +101,11 @@ def build_parser():
     task_retry_limit_group = task_retry_limit_parser.add_mutually_exclusive_group(required=True)
     task_retry_limit_group.add_argument("--limit", type=int)
     task_retry_limit_group.add_argument("--clear", action="store_true")
+
+    task_release_retry_backoff_parser = task_subparsers.add_parser("release-retry-backoff")
+    task_release_retry_backoff_parser.add_argument("--project-root", default=".")
+    task_release_retry_backoff_parser.add_argument("--task-id", required=True)
+    task_release_retry_backoff_parser.add_argument("--actor-id", required=True)
 
     task_allocate_parser = task_subparsers.add_parser("allocate")
     task_allocate_parser.add_argument("--project-root", default=".")
@@ -318,6 +324,8 @@ def command_task(args):
                     indent=2,
                 )
             )
+        elif args.task_command == "release-retry-backoff":
+            print(json.dumps(release_task_retry_backoff(connection, args.task_id, args.actor_id), indent=2))
         elif args.task_command == "allocate":
             if args.agent_id:
                 print(json.dumps(assign_next_task(connection, args.agent_id, actor_id=args.actor_id), indent=2))

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -261,6 +261,74 @@ def set_task_retry_limit(connection, task_id, actor_id, auto_retry_limit=None):
     return {"task_id": task_id, "auto_retry_limit": normalized_limit}
 
 
+def release_task_retry_backoff(connection, task_id, actor_id):
+    task = connection.execute(
+        """
+        SELECT task_id, project_id, assigned_agent_id, status, review_state, next_retry_at, next_retry_reason
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        raise ValueError("Task not found")
+    ensure_board_action_allowed(connection, actor_id, task["project_id"], "release_task_retry_backoff", "task", task_id)
+    if task["status"] in ("done", "cancelled"):
+        raise ValueError("Retry backoff cannot be released for tasks in status {0}".format(task["status"]))
+    if task["review_state"] != "retry_backoff" and task["next_retry_at"] is None:
+        raise ValueError("Task is not currently waiting on retry backoff")
+
+    connection.execute(
+        """
+        UPDATE tasks
+        SET next_retry_at = NULL,
+            next_retry_reason = NULL,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    )
+    refreshed = refresh_ready_tasks(connection, commit=False)
+    task_after = connection.execute(
+        """
+        SELECT status, review_state, next_retry_at, next_retry_reason
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    _audit(
+        connection,
+        task["project_id"],
+        actor_id,
+        "release_task_retry_backoff",
+        "task",
+        task_id,
+        {
+            "previous_review_state": task["review_state"],
+            "previous_next_retry_at": task["next_retry_at"],
+            "previous_next_retry_reason": task["next_retry_reason"],
+            "ready_changes": refreshed,
+        },
+    )
+    _activity(
+        connection,
+        task["project_id"],
+        task["assigned_agent_id"],
+        task_id,
+        "retry_backoff_released",
+        "Task retry cooldown released by operator and readiness re-evaluated.",
+    )
+    connection.commit()
+    return {
+        "task_id": task_id,
+        "status": task_after["status"],
+        "review_state": task_after["review_state"],
+        "next_retry_at": task_after["next_retry_at"],
+        "next_retry_reason": task_after["next_retry_reason"],
+    }
+
+
 def recover_and_requeue_task(connection, task_id, actor_id):
     task = _load_recoverable_task(connection, task_id, actor_id)
     refreshed_task = _recover_and_requeue_task(connection, task, actor_id)

--- a/tests/test_api_board_actions.py
+++ b/tests/test_api_board_actions.py
@@ -269,6 +269,76 @@ class BoardApiActionsTest(unittest.TestCase):
             )
             self.assertEqual(forbidden_response.status_code, 403)
 
+    def test_release_retry_backoff_returns_task_to_ready_when_unblocked(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Release Backoff Test", description="Release retry backoff", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Wire the scheduler and board read model'"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'planned',
+                        review_state = 'retry_backoff',
+                        next_retry_at = '2099-01-01 00:00:00',
+                        next_retry_reason = 'session_failed'
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            response = client.post(
+                "/api/tasks/{0}/actions/release-retry-backoff".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["status"], "ready")
+            self.assertIsNone(payload["review_state"])
+            self.assertIsNone(payload["next_retry_at"])
+            self.assertIsNone(payload["next_retry_reason"])
+
+    def test_release_retry_backoff_respects_dependency_blockers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Release Backoff Blocked Test", description="Release retry backoff blocked", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Implement FastAPI board endpoint'"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'planned',
+                        review_state = 'retry_backoff',
+                        next_retry_at = '2099-01-01 00:00:00',
+                        next_retry_reason = 'session_timed_out'
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            response = client.post(
+                "/api/tasks/{0}/actions/release-retry-backoff".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["review_state"], "blocked_by_dependency")
+            self.assertIsNone(payload["next_retry_at"])
+            self.assertIsNone(payload["next_retry_reason"])
+
     def test_recover_failed_task_returns_it_to_planned_queue(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(tmpdir, name="Recover Task Test", description="Recover failure-blocked task", project_type="custom")

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -576,6 +576,13 @@ export async function setTaskRetryLimit(taskId: string, autoRetryLimit: number |
   return payload;
 }
 
+export async function releaseTaskRetryBackoff(taskId: string) {
+  const payload = await postJson(`/api/tasks/${taskId}/actions/release-retry-backoff`, {
+    actor_id: "agent_allocator"
+  });
+  return payload;
+}
+
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
 

--- a/web/src/pages/RecoveryPage.tsx
+++ b/web/src/pages/RecoveryPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { StatCard } from "../components/StatCard";
-import { fetchRecoveryPolicy, setRecoveryPolicy, setTaskRetryLimit } from "../lib/controlRoomApi";
+import { fetchRecoveryPolicy, releaseTaskRetryBackoff, setRecoveryPolicy, setTaskRetryLimit } from "../lib/controlRoomApi";
 import { useLivePulse } from "../lib/useLivePulse";
 import type { RecoveryPolicyResponse, RecoveryPolicySettings, RecoveryTaskItem } from "../types";
 
@@ -77,11 +77,13 @@ function formatRetryLimit(autoRetryLimit?: number | null) {
 function RecoveryTaskList({
   items,
   pendingTaskId,
-  onRetryLimitChange
+  onRetryLimitChange,
+  onPrimaryAction
 }: {
   items: RecoveryTaskItem[];
   pendingTaskId: string | null;
   onRetryLimitChange: (taskId: string, autoRetryLimit: number | null) => void;
+  onPrimaryAction?: (taskId: string) => void;
 }) {
   return (
     <div className="data-list">
@@ -113,6 +115,16 @@ function RecoveryTaskList({
           <div className="data-list__meta">
             <span>P{item.priority}</span>
             {item.latest_failure_at ? <span>{new Date(item.latest_failure_at).toLocaleString()}</span> : null}
+            {onPrimaryAction ? (
+              <button
+                type="button"
+                className="task-action task-action--approve"
+                disabled={pendingTaskId === item.task_id}
+                onClick={() => onPrimaryAction(item.task_id)}
+              >
+                {pendingTaskId === item.task_id ? "Releasing..." : "Release backoff"}
+              </button>
+            ) : null}
             <label className="task-inline-control">
               <span>Retry limit</span>
               <select
@@ -219,6 +231,20 @@ export function RecoveryPage() {
       );
     } catch {
       setNotice("Task retry limit update failed; keeping the current recovery snapshot under review.");
+    } finally {
+      setPendingTaskRetryLimit(null);
+    }
+  }
+
+  async function handleReleaseRetryBackoff(taskId: string) {
+    setPendingTaskRetryLimit(taskId);
+    setNotice(null);
+    try {
+      const payload = await releaseTaskRetryBackoff(taskId);
+      await reload();
+      setNotice(`Released retry backoff for ${taskId}; task is now ${payload.status}.`);
+    } catch {
+      setNotice("Retry backoff release failed; keep the current recovery snapshot under review.");
     } finally {
       setPendingTaskRetryLimit(null);
     }
@@ -425,6 +451,7 @@ export function RecoveryPage() {
               items={recovery?.active_retry_backoff ?? []}
               pendingTaskId={pendingTaskRetryLimit}
               onRetryLimitChange={handleTaskRetryLimitChange}
+              onPrimaryAction={(taskId) => void handleReleaseRetryBackoff(taskId)}
             />
           ) : (
             <div className="data-list">


### PR DESCRIPTION
## Done on main
- [x] Project-level recovery policy controls and Recovery view
- [x] Task-level retry override controls on the Board and in the Recovery task-exception view
- [x] Timed-out and failed-session auto-retry, retry backoff, and failure/quarantine workflows

## Working in this PR
- [x] Add a first-class task action to release retry backoff early from operator control
- [x] Clear retry cooldown metadata and re-run readiness evaluation in the same transaction
- [x] Expose the action through API and CLI
- [x] Surface `Release backoff` directly on active cooldown tasks in the Recovery view
- [x] Add focused API tests for both the ready path and the dependency-blocked guardrail

## Still to do
- [ ] Richer task-level recovery controls beyond retry budget and manual backoff release
- [ ] Broader automated restart/recovery orchestration and policy layers
- [ ] Brownfield and multi-project recovery views

## Validation
- [x] `PYTHONPATH=src python3 -m py_compile src/maas/services/steering.py src/maas/api.py src/maas/cli.py tests/test_api_board_actions.py`
- [x] `PYTHONPATH=src python3 -m unittest tests.test_api_board_actions`
- [x] `git diff --check`

## Risks
- [ ] Frontend build not run in this checkout because local `tsc` is still not installed