### PR TITLE
Add task retry state reset controls

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -30,6 +30,7 @@ from maas.services.steering import (
     recover_agent,
     recover_task,
     release_task_retry_backoff,
+    reset_task_retry_state,
     reopen_quarantine_entry,
     restore_and_requeue_quarantine_entry,
     restore_quarantine_entry,
@@ -732,6 +733,18 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             return release_task_retry_backoff(connection, task_id, payload.actor_id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/tasks/{task_id}/actions/reset-retry-state")
+    def task_reset_retry_state_action(task_id: str, payload: AgentActionRequest):
+        connection = connect(paths)
+        try:
+            return reset_task_retry_state(connection, task_id, payload.actor_id)
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
         except ValueError as exc:

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -23,6 +23,7 @@ from maas.services.steering import (
     recover_and_requeue_task,
     recover_task,
     release_task_retry_backoff,
+    reset_task_retry_state,
     resolve_task_repeated_failures,
     set_task_retry_limit,
     restore_and_requeue_quarantine_entry,
@@ -106,6 +107,11 @@ def build_parser():
     task_release_retry_backoff_parser.add_argument("--project-root", default=".")
     task_release_retry_backoff_parser.add_argument("--task-id", required=True)
     task_release_retry_backoff_parser.add_argument("--actor-id", required=True)
+
+    task_reset_retry_state_parser = task_subparsers.add_parser("reset-retry-state")
+    task_reset_retry_state_parser.add_argument("--project-root", default=".")
+    task_reset_retry_state_parser.add_argument("--task-id", required=True)
+    task_reset_retry_state_parser.add_argument("--actor-id", required=True)
 
     task_allocate_parser = task_subparsers.add_parser("allocate")
     task_allocate_parser.add_argument("--project-root", default=".")
@@ -326,6 +332,8 @@ def command_task(args):
             )
         elif args.task_command == "release-retry-backoff":
             print(json.dumps(release_task_retry_backoff(connection, args.task_id, args.actor_id), indent=2))
+        elif args.task_command == "reset-retry-state":
+            print(json.dumps(reset_task_retry_state(connection, args.task_id, args.actor_id), indent=2))
         elif args.task_command == "allocate":
             if args.agent_id:
                 print(json.dumps(assign_next_task(connection, args.agent_id, actor_id=args.actor_id), indent=2))

--- a/src/maas/services/recovery_policy.py
+++ b/src/maas/services/recovery_policy.py
@@ -118,7 +118,12 @@ def _recovery_summary(connection, project_id):
         """
         SELECT
             SUM(CASE WHEN review_state = 'retry_backoff' THEN 1 ELSE 0 END) AS retry_backoff_tasks,
-            SUM(CASE WHEN COALESCE(retry_count, 0) > 0 THEN 1 ELSE 0 END) AS tasks_with_retry_history,
+            SUM(
+                CASE
+                    WHEN status NOT IN ('done', 'cancelled') AND COALESCE(retry_count, 0) > 0 THEN 1
+                    ELSE 0
+                END
+            ) AS tasks_with_retry_history,
             SUM(
                 CASE
                     WHEN status = 'blocked' AND review_state IN ('session_failed', 'stale_session') THEN 1
@@ -247,6 +252,12 @@ def fetch_project_recovery_overview(connection, project_id=None):
             connection,
             project_id,
             "tasks.auto_retry_limit IS NOT NULL AND tasks.status NOT IN ('done', 'cancelled')",
+            [],
+        ),
+        "task_retry_history": _recovery_task_items(
+            connection,
+            project_id,
+            "tasks.status NOT IN ('done', 'cancelled') AND COALESCE(tasks.retry_count, 0) > 0",
             [],
         ),
         "active_retry_backoff": _recovery_task_items(

--- a/src/maas/services/steering.py
+++ b/src/maas/services/steering.py
@@ -329,6 +329,103 @@ def release_task_retry_backoff(connection, task_id, actor_id):
     }
 
 
+def reset_task_retry_state(connection, task_id, actor_id):
+    task = connection.execute(
+        """
+        SELECT
+            task_id,
+            project_id,
+            assigned_agent_id,
+            status,
+            review_state,
+            retry_count,
+            last_retry_at,
+            last_retry_reason,
+            next_retry_at,
+            next_retry_reason
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        raise ValueError("Task not found")
+    ensure_board_action_allowed(connection, actor_id, task["project_id"], "reset_task_retry_state", "task", task_id)
+    if task["status"] in ("done", "cancelled"):
+        raise ValueError("Retry state cannot be reset for tasks in status {0}".format(task["status"]))
+    has_retry_state = any(
+        (
+            task["retry_count"],
+            task["last_retry_at"],
+            task["last_retry_reason"],
+            task["next_retry_at"],
+            task["next_retry_reason"],
+            task["review_state"] == "retry_backoff",
+        )
+    )
+    if not has_retry_state:
+        raise ValueError("Task has no retry state to reset")
+
+    connection.execute(
+        """
+        UPDATE tasks
+        SET retry_count = 0,
+            last_retry_at = NULL,
+            last_retry_reason = NULL,
+            next_retry_at = NULL,
+            next_retry_reason = NULL,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    )
+    refreshed = refresh_ready_tasks(connection, commit=False)
+    task_after = connection.execute(
+        """
+        SELECT status, review_state, retry_count, last_retry_at, last_retry_reason, next_retry_at, next_retry_reason
+        FROM tasks
+        WHERE task_id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    _audit(
+        connection,
+        task["project_id"],
+        actor_id,
+        "reset_task_retry_state",
+        "task",
+        task_id,
+        {
+            "previous_retry_count": task["retry_count"],
+            "previous_last_retry_at": task["last_retry_at"],
+            "previous_last_retry_reason": task["last_retry_reason"],
+            "previous_next_retry_at": task["next_retry_at"],
+            "previous_next_retry_reason": task["next_retry_reason"],
+            "previous_review_state": task["review_state"],
+            "ready_changes": refreshed,
+        },
+    )
+    _activity(
+        connection,
+        task["project_id"],
+        task["assigned_agent_id"],
+        task_id,
+        "retry_state_reset",
+        "Task retry history and cooldown metadata reset by operator.",
+    )
+    connection.commit()
+    return {
+        "task_id": task_id,
+        "status": task_after["status"],
+        "review_state": task_after["review_state"],
+        "retry_count": task_after["retry_count"],
+        "last_retry_at": task_after["last_retry_at"],
+        "last_retry_reason": task_after["last_retry_reason"],
+        "next_retry_at": task_after["next_retry_at"],
+        "next_retry_reason": task_after["next_retry_reason"],
+    }
+
+
 def recover_and_requeue_task(connection, task_id, actor_id):
     task = _load_recoverable_task(connection, task_id, actor_id)
     refreshed_task = _recover_and_requeue_task(connection, task, actor_id)

--- a/tests/test_api_board_actions.py
+++ b/tests/test_api_board_actions.py
@@ -339,6 +339,66 @@ class BoardApiActionsTest(unittest.TestCase):
             self.assertIsNone(payload["next_retry_at"])
             self.assertIsNone(payload["next_retry_reason"])
 
+    def test_reset_retry_state_clears_history_and_releases_ready_task(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Reset Retry State Test", description="Reset retry state", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE title = 'Wire the scheduler and board read model'"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'planned',
+                        review_state = 'retry_backoff',
+                        retry_count = 2,
+                        last_retry_at = CURRENT_TIMESTAMP,
+                        last_retry_reason = 'session_failed',
+                        next_retry_at = '2099-01-01 00:00:00',
+                        next_retry_reason = 'session_failed'
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            response = client.post(
+                "/api/tasks/{0}/actions/reset-retry-state".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["status"], "ready")
+            self.assertIsNone(payload["review_state"])
+            self.assertEqual(payload["retry_count"], 0)
+            self.assertIsNone(payload["last_retry_at"])
+            self.assertIsNone(payload["last_retry_reason"])
+            self.assertIsNone(payload["next_retry_at"])
+            self.assertIsNone(payload["next_retry_reason"])
+
+    def test_reset_retry_state_rejects_clean_task(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Reset Retry State Clean Test", description="Reset retry state clean", project_type="custom")
+            client = TestClient(create_app(tmpdir))
+            board_payload = client.get("/api/board", params={"search": "Wire the scheduler and board read model"}).json()
+            task_id = [
+                item
+                for column in board_payload["columns"]
+                for item in column["tasks"]
+                if item["title"] == "Wire the scheduler and board read model"
+            ][0]["task_id"]
+
+            response = client.post(
+                "/api/tasks/{0}/actions/reset-retry-state".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("no retry state", response.json()["detail"])
+
     def test_recover_failed_task_returns_it_to_planned_queue(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(tmpdir, name="Recover Task Test", description="Recover failure-blocked task", project_type="custom")

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -503,6 +503,77 @@ class LifecycleStateTransitionTest(unittest.TestCase):
             self.assertIsNone(task["next_retry_reason"])
             self.assertEqual(alert["status"], "open")
 
+    def test_reset_retry_state_restores_failed_session_auto_retry_budget(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Lifecycle Reset Retry State Test",
+                description="Lifecycle reset retry state test",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                self._update_recovery_config(
+                    connection,
+                    auto_retry_failed_sessions=True,
+                    max_failed_session_retries=1,
+                    failed_session_retry_cooldown_seconds=45,
+                )
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                task_id = connection.execute(
+                    "SELECT task_id FROM tasks WHERE status = 'ready' LIMIT 1"
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET retry_count = 1, last_retry_reason = 'session_failed'
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            reset_response = client.post(
+                "/api/tasks/{0}/actions/reset-retry-state".format(task_id),
+                json={"actor_id": "agent_allocator"},
+            )
+            self.assertEqual(reset_response.status_code, 200)
+            self.assertEqual(reset_response.json()["retry_count"], 0)
+
+            connection = connect(result["paths"])
+            try:
+                session_id = start_session(
+                    connection,
+                    project_id=project_id,
+                    agent_id="agent_allocator",
+                    task_id=task_id,
+                    provider_type="python_script",
+                    status_message="Starting lifecycle reset retry state test",
+                )
+
+                end_session(connection, session_id, "failed", "Retry budget restored")
+
+                task = connection.execute(
+                    """
+                    SELECT status, review_state, retry_count, last_retry_reason, next_retry_at, next_retry_reason
+                    FROM tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+            finally:
+                connection.close()
+
+            self.assertEqual(task["status"], "planned")
+            self.assertEqual(task["review_state"], "retry_backoff")
+            self.assertEqual(task["retry_count"], 1)
+            self.assertEqual(task["last_retry_reason"], "session_failed")
+            self.assertIsNotNone(task["next_retry_at"])
+            self.assertEqual(task["next_retry_reason"], "session_failed")
+
     def test_failed_session_quarantines_session_artifacts(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(

--- a/tests/test_recovery_policy_api.py
+++ b/tests/test_recovery_policy_api.py
@@ -111,7 +111,7 @@ class RecoveryPolicyApiTest(unittest.TestCase):
             self.assertEqual(config["providers"]["openai_codex"]["model"], "gpt-5-codex")
             self.assertEqual(config["recovery"]["retry_backoff_multiplier"], 3)
 
-    def test_recovery_policy_endpoint_includes_task_overrides_and_active_backoff_tasks(self):
+    def test_recovery_policy_endpoint_includes_task_overrides_retry_history_and_active_backoff_tasks(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Recovery Policy Test", description="Recovery policy test", project_type="custom")
             connection = connect(project_paths(tmpdir))
@@ -151,10 +151,15 @@ class RecoveryPolicyApiTest(unittest.TestCase):
 
             self.assertEqual(payload["summary"]["tasks_with_retry_overrides"], 1)
             self.assertEqual(payload["summary"]["retry_backoff_tasks"], 1)
+            self.assertEqual(payload["summary"]["tasks_with_retry_history"], 1)
 
             override_items = {item["task_id"]: item for item in payload["task_retry_overrides"]}
             self.assertEqual(override_items[override_task_id]["auto_retry_limit"], 5)
             self.assertEqual(override_items[override_task_id]["title"], "Wire the scheduler and board read model")
+
+            retry_history_items = {item["task_id"]: item for item in payload["task_retry_history"]}
+            self.assertEqual(retry_history_items[backoff_task_id]["retry_count"], 1)
+            self.assertEqual(retry_history_items[backoff_task_id]["last_retry_reason"], None)
 
             backoff_items = {item["task_id"]: item for item in payload["active_retry_backoff"]}
             self.assertEqual(backoff_items[backoff_task_id]["review_state"], "retry_backoff")
@@ -175,7 +180,8 @@ class RecoveryPolicyApiTest(unittest.TestCase):
                     """
                     UPDATE tasks
                     SET status = 'done',
-                        auto_retry_limit = 4
+                        auto_retry_limit = 4,
+                        retry_count = 2
                     WHERE task_id = ?
                     """,
                     (done_task_id,),
@@ -185,6 +191,7 @@ class RecoveryPolicyApiTest(unittest.TestCase):
                     UPDATE tasks
                     SET status = 'cancelled',
                         auto_retry_limit = 2,
+                        retry_count = 1,
                         next_retry_at = '2099-01-01 00:00:00',
                         next_retry_reason = 'session_failed'
                     WHERE task_id = ?
@@ -199,10 +206,14 @@ class RecoveryPolicyApiTest(unittest.TestCase):
             payload = client.get("/api/recovery-policy").json()
 
             self.assertEqual(payload["summary"]["tasks_with_retry_overrides"], 0)
+            self.assertEqual(payload["summary"]["tasks_with_retry_history"], 0)
             override_task_ids = {item["task_id"] for item in payload["task_retry_overrides"]}
+            retry_history_task_ids = {item["task_id"] for item in payload["task_retry_history"]}
             backoff_task_ids = {item["task_id"] for item in payload["active_retry_backoff"]}
             self.assertNotIn(done_task_id, override_task_ids)
             self.assertNotIn(cancelled_task_id, override_task_ids)
+            self.assertNotIn(done_task_id, retry_history_task_ids)
+            self.assertNotIn(cancelled_task_id, retry_history_task_ids)
             self.assertNotIn(done_task_id, backoff_task_ids)
             self.assertNotIn(cancelled_task_id, backoff_task_ids)
 

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -380,6 +380,7 @@ const RECOVERY_POLICY_FALLBACK: RecoveryPolicyResponse = {
     ]
   },
   task_retry_overrides: [],
+  task_retry_history: [],
   active_retry_backoff: []
 };
 
@@ -578,6 +579,13 @@ export async function setTaskRetryLimit(taskId: string, autoRetryLimit: number |
 
 export async function releaseTaskRetryBackoff(taskId: string) {
   const payload = await postJson(`/api/tasks/${taskId}/actions/release-retry-backoff`, {
+    actor_id: "agent_allocator"
+  });
+  return payload;
+}
+
+export async function resetTaskRetryState(taskId: string) {
+  const payload = await postJson(`/api/tasks/${taskId}/actions/reset-retry-state`, {
     actor_id: "agent_allocator"
   });
   return payload;

--- a/web/src/pages/RecoveryPage.tsx
+++ b/web/src/pages/RecoveryPage.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { StatCard } from "../components/StatCard";
-import { fetchRecoveryPolicy, releaseTaskRetryBackoff, setRecoveryPolicy, setTaskRetryLimit } from "../lib/controlRoomApi";
+import {
+  fetchRecoveryPolicy,
+  releaseTaskRetryBackoff,
+  resetTaskRetryState,
+  setRecoveryPolicy,
+  setTaskRetryLimit
+} from "../lib/controlRoomApi";
 import { useLivePulse } from "../lib/useLivePulse";
 import type { RecoveryPolicyResponse, RecoveryPolicySettings, RecoveryTaskItem } from "../types";
 
@@ -78,12 +84,16 @@ function RecoveryTaskList({
   items,
   pendingTaskId,
   onRetryLimitChange,
-  onPrimaryAction
+  onPrimaryAction,
+  primaryActionLabel,
+  pendingPrimaryActionLabel
 }: {
   items: RecoveryTaskItem[];
   pendingTaskId: string | null;
   onRetryLimitChange: (taskId: string, autoRetryLimit: number | null) => void;
   onPrimaryAction?: (taskId: string) => void;
+  primaryActionLabel?: string;
+  pendingPrimaryActionLabel?: string;
 }) {
   return (
     <div className="data-list">
@@ -122,7 +132,7 @@ function RecoveryTaskList({
                 disabled={pendingTaskId === item.task_id}
                 onClick={() => onPrimaryAction(item.task_id)}
               >
-                {pendingTaskId === item.task_id ? "Releasing..." : "Release backoff"}
+                {pendingTaskId === item.task_id ? (pendingPrimaryActionLabel ?? "Working...") : (primaryActionLabel ?? "Run action")}
               </button>
             ) : null}
             <label className="task-inline-control">
@@ -153,7 +163,7 @@ export function RecoveryPage() {
   const [draft, setDraft] = useState<RecoveryDraft | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [pendingSave, setPendingSave] = useState(false);
-  const [pendingTaskRetryLimit, setPendingTaskRetryLimit] = useState<string | null>(null);
+  const [pendingTaskActionId, setPendingTaskActionId] = useState<string | null>(null);
   const livePulse = useLivePulse();
 
   useEffect(() => {
@@ -219,7 +229,7 @@ export function RecoveryPage() {
   }
 
   async function handleTaskRetryLimitChange(taskId: string, autoRetryLimit: number | null) {
-    setPendingTaskRetryLimit(taskId);
+    setPendingTaskActionId(taskId);
     setNotice(null);
     try {
       await setTaskRetryLimit(taskId, autoRetryLimit);
@@ -232,12 +242,12 @@ export function RecoveryPage() {
     } catch {
       setNotice("Task retry limit update failed; keeping the current recovery snapshot under review.");
     } finally {
-      setPendingTaskRetryLimit(null);
+      setPendingTaskActionId(null);
     }
   }
 
   async function handleReleaseRetryBackoff(taskId: string) {
-    setPendingTaskRetryLimit(taskId);
+    setPendingTaskActionId(taskId);
     setNotice(null);
     try {
       const payload = await releaseTaskRetryBackoff(taskId);
@@ -246,7 +256,21 @@ export function RecoveryPage() {
     } catch {
       setNotice("Retry backoff release failed; keep the current recovery snapshot under review.");
     } finally {
-      setPendingTaskRetryLimit(null);
+      setPendingTaskActionId(null);
+    }
+  }
+
+  async function handleResetRetryState(taskId: string) {
+    setPendingTaskActionId(taskId);
+    setNotice(null);
+    try {
+      const payload = await resetTaskRetryState(taskId);
+      await reload();
+      setNotice(`Reset retry state for ${taskId}; task is now ${payload.status}.`);
+    } catch {
+      setNotice("Retry state reset failed; keep the current recovery snapshot under review.");
+    } finally {
+      setPendingTaskActionId(null);
     }
   }
 
@@ -424,7 +448,7 @@ export function RecoveryPage() {
           {(recovery?.task_retry_overrides ?? []).length ? (
             <RecoveryTaskList
               items={recovery?.task_retry_overrides ?? []}
-              pendingTaskId={pendingTaskRetryLimit}
+              pendingTaskId={pendingTaskActionId}
               onRetryLimitChange={handleTaskRetryLimitChange}
             />
           ) : (
@@ -442,6 +466,34 @@ export function RecoveryPage() {
         <article className="data-panel">
           <header className="data-panel__header">
             <div>
+              <h2>Retry history</h2>
+              <p>Tasks that have already consumed automatic retries. Reset the task state here after manual intervention to restore the retry budget.</p>
+            </div>
+          </header>
+          {(recovery?.task_retry_history ?? []).length ? (
+            <RecoveryTaskList
+              items={recovery?.task_retry_history ?? []}
+              pendingTaskId={pendingTaskActionId}
+              onRetryLimitChange={handleTaskRetryLimitChange}
+              onPrimaryAction={(taskId) => void handleResetRetryState(taskId)}
+              primaryActionLabel="Reset retry state"
+              pendingPrimaryActionLabel="Resetting..."
+            />
+          ) : (
+            <div className="data-list">
+              <div className="data-list__item">
+                <div>
+                  <strong>No retry history</strong>
+                  <p>No active tasks currently carry consumed retry budget.</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </article>
+
+        <article className="data-panel">
+          <header className="data-panel__header">
+            <div>
               <h2>Active retry backoff</h2>
               <p>Tasks currently cooling down before another automatic or operator-triggered retry window opens.</p>
             </div>
@@ -449,9 +501,11 @@ export function RecoveryPage() {
           {(recovery?.active_retry_backoff ?? []).length ? (
             <RecoveryTaskList
               items={recovery?.active_retry_backoff ?? []}
-              pendingTaskId={pendingTaskRetryLimit}
+              pendingTaskId={pendingTaskActionId}
               onRetryLimitChange={handleTaskRetryLimitChange}
               onPrimaryAction={(taskId) => void handleReleaseRetryBackoff(taskId)}
+              primaryActionLabel="Release backoff"
+              pendingPrimaryActionLabel="Releasing..."
             />
           ) : (
             <div className="data-list">
@@ -464,6 +518,7 @@ export function RecoveryPage() {
             </div>
           )}
         </article>
+
       </section>
     </section>
   );

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -557,6 +557,7 @@ export interface RecoveryPolicyResponse {
     recover_and_requeue_delays: RecoveryDelayPreviewItem[];
   };
   task_retry_overrides: RecoveryTaskItem[];
+  task_retry_history: RecoveryTaskItem[];
   active_retry_backoff: RecoveryTaskItem[];
 }
 


### PR DESCRIPTION
## Done on main
- [x] Project-level recovery policy controls and previews
- [x] Task retry-limit overrides and active retry backoff controls
- [x] Manual release of retry cooldown from the Recovery page
- [x] Failed-session and timed-out auto-retry paths with task/project retry budgets

## Working in this PR
- [ ] Add a first-class `reset retry state` action for tasks with consumed retry budget
- [ ] Clear retry counters, last-retry metadata, and cooldown metadata in one atomic operator action
- [ ] Re-run readiness evaluation after reset so retry-backoff tasks become ready or blocked immediately
- [ ] Surface retry-history tasks and the reset action from the Recovery page
- [ ] Add regressions proving retry-budget reset restores failed-session auto-retry eligibility

## Still to do
- [ ] Broader recovery automation beyond current timeout and failed-session paths
- [ ] More provider/runtime policy controls beyond retry state and cooldown management
- [ ] Brownfield onboarding and multi-project support
- [ ] Stronger sandboxing and isolation