### PR TITLE
Normalize provider runtime failure kinds

### DIFF
--- a/src/maas/providers.py
+++ b/src/maas/providers.py
@@ -286,8 +286,110 @@ def _provider_run_history(connection, project_id):
             "timed_out_runs": row["timed_out_runs"],
             "cancelled_runs": row["cancelled_runs"],
             "last_run_at": row["last_run_at"],
+            "timeout_failures": 0,
+            "nonzero_exit_failures": 0,
+            "runtime_failures": 0,
+            "latest_failure_kind": None,
+            "latest_failure_at": None,
         }
         for row in summary_rows
+    }
+
+    failure_rows = connection.execute(
+        """
+        SELECT
+            sessions.provider_type,
+            activity_log.created_at,
+            json_extract(activity_log.details_json, '$.failure_kind') AS failure_kind
+        FROM activity_log
+        JOIN sessions
+          ON sessions.session_id = json_extract(activity_log.details_json, '$.session_id')
+        WHERE activity_log.project_id = ?
+          AND activity_log.action = 'provider_adapter_failed'
+        ORDER BY activity_log.created_at DESC, activity_log.rowid DESC
+        """,
+        (project_id,),
+    ).fetchall()
+    for row in failure_rows:
+        summary = summaries.setdefault(
+            row["provider_type"],
+            {
+                "total_runs": 0,
+                "active_runs": 0,
+                "completed_runs": 0,
+                "failed_runs": 0,
+                "timed_out_runs": 0,
+                "cancelled_runs": 0,
+                "last_run_at": None,
+                "timeout_failures": 0,
+                "nonzero_exit_failures": 0,
+                "runtime_failures": 0,
+                "latest_failure_kind": None,
+                "latest_failure_at": None,
+            },
+        )
+        failure_kind = row["failure_kind"] or "runtime_error"
+        if failure_kind == "timeout":
+            summary["timeout_failures"] += 1
+        elif failure_kind == "nonzero_exit":
+            summary["nonzero_exit_failures"] += 1
+        else:
+            summary["runtime_failures"] += 1
+        if summary["latest_failure_at"] is None:
+            summary["latest_failure_at"] = row["created_at"]
+            summary["latest_failure_kind"] = failure_kind
+
+    started_rows = connection.execute(
+        """
+        SELECT
+            json_extract(details_json, '$.session_id') AS session_id,
+            json_extract(details_json, '$.execution_mode') AS execution_mode,
+            json_extract(details_json, '$.external_runtime') AS external_runtime
+        FROM activity_log
+        WHERE project_id = ?
+          AND action = 'provider_adapter_started'
+        """,
+        (project_id,),
+    ).fetchall()
+    started_by_session = {
+        row["session_id"]: {
+            "execution_mode": row["execution_mode"],
+            "external_runtime": row["external_runtime"],
+        }
+        for row in started_rows
+        if row["session_id"]
+    }
+
+    failure_detail_rows = connection.execute(
+        """
+        SELECT
+            ranked.session_id,
+            ranked.failure_kind,
+            ranked.failure_detail
+        FROM (
+            SELECT
+                json_extract(details_json, '$.session_id') AS session_id,
+                json_extract(details_json, '$.failure_kind') AS failure_kind,
+                json_extract(details_json, '$.failure_detail') AS failure_detail,
+                ROW_NUMBER() OVER (
+                    PARTITION BY json_extract(details_json, '$.session_id')
+                    ORDER BY rowid DESC
+                ) AS session_rank
+            FROM activity_log
+            WHERE project_id = ?
+              AND action = 'provider_adapter_failed'
+        ) AS ranked
+        WHERE ranked.session_rank = 1
+        """,
+        (project_id,),
+    ).fetchall()
+    failure_by_session = {
+        row["session_id"]: {
+            "failure_kind": row["failure_kind"] or "runtime_error",
+            "failure_detail": row["failure_detail"],
+        }
+        for row in failure_detail_rows
+        if row["session_id"]
     }
 
     recent_rows = connection.execute(
@@ -335,6 +437,8 @@ def _provider_run_history(connection, project_id):
     recent_runs = {}
     for row in recent_rows:
         entries = recent_runs.setdefault(row["provider_type"], [])
+        started = started_by_session.get(row["session_id"], {})
+        failure = failure_by_session.get(row["session_id"], {})
         entries.append(
             {
                 "session_id": row["session_id"],
@@ -347,6 +451,10 @@ def _provider_run_history(connection, project_id):
                 "status_message": row["status_message"],
                 "started_at": row["started_at"],
                 "ended_at": row["ended_at"],
+                "execution_mode": started.get("execution_mode"),
+                "external_runtime": started.get("external_runtime"),
+                "failure_kind": failure.get("failure_kind"),
+                "failure_detail": failure.get("failure_detail"),
             }
         )
     return {"summaries": summaries, "recent_runs": recent_runs}
@@ -590,6 +698,11 @@ def list_provider_status(connection=None, project_id=None):
                 "timed_out_runs": 0,
                 "cancelled_runs": 0,
                 "last_run_at": None,
+                "timeout_failures": 0,
+                "nonzero_exit_failures": 0,
+                "runtime_failures": 0,
+                "latest_failure_kind": None,
+                "latest_failure_at": None,
             },
         )
         resolved_provider["recent_runs"] = run_history.get("recent_runs", {}).get(provider["id"], [])

--- a/src/maas/services/provider_runtime.py
+++ b/src/maas/services/provider_runtime.py
@@ -14,6 +14,13 @@ from maas.providers import (
 from maas.services.lifecycle import end_session, heartbeat, log_activity, produce_artifact, start_session
 
 
+class ProviderRuntimeFailure(RuntimeError):
+    def __init__(self, kind, message, **details):
+        super().__init__(message)
+        self.kind = kind
+        self.details = details
+
+
 def _task_title(connection, task_id):
     row = connection.execute("SELECT title FROM tasks WHERE task_id = ?", (task_id,)).fetchone()
     return row["title"] if row else task_id
@@ -199,20 +206,44 @@ def _run_openai_codex_cli(project_paths, provider_settings, task_prompt):
 
     command = _codex_cli_command(project_paths, provider_settings, task_prompt, output_path)
     try:
-        result = subprocess.run(
-            command,
-            cwd=project_paths.root,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(
-                "Codex CLI exited with status {0}: {1}".format(result.returncode, (result.stderr or "").strip() or "unknown error")
+        try:
+            result = subprocess.run(
+                command,
+                cwd=project_paths.root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
             )
-        with open(output_path, "r", encoding="utf-8") as output_handle:
-            final_message = output_handle.read().strip()
+        except subprocess.TimeoutExpired as exc:
+            raise ProviderRuntimeFailure(
+                "timeout",
+                "Codex CLI timed out after {0}s.".format(timeout_seconds),
+                timeout_seconds=timeout_seconds,
+                command=command,
+            ) from exc
+        if result.returncode != 0:
+            raise ProviderRuntimeFailure(
+                "nonzero_exit",
+                "Codex CLI exited with status {0}: {1}".format(
+                    result.returncode,
+                    (result.stderr or "").strip() or "unknown error",
+                ),
+                exit_code=result.returncode,
+                stderr=(result.stderr or "").strip(),
+                stdout=(result.stdout or "").strip(),
+                command=command,
+            )
+        try:
+            with open(output_path, "r", encoding="utf-8") as output_handle:
+                final_message = output_handle.read().strip()
+        except OSError as exc:
+            raise ProviderRuntimeFailure(
+                "output_read_failed",
+                "Codex CLI completed but the runtime output file could not be read: {0}".format(exc),
+                command=command,
+                output_path=output_path,
+            ) from exc
         return {
             "summary_text": final_message or "Codex CLI completed without a final message.",
             "stdout": result.stdout or "",
@@ -226,23 +257,51 @@ def _run_openai_codex_cli(project_paths, provider_settings, task_prompt):
 def _run_claude_code_cli(project_paths, provider_settings, task_prompt):
     timeout_seconds = int(provider_settings.get("timeout_seconds") or 300)
     command = _claude_cli_command(project_paths, provider_settings, task_prompt)
-    result = subprocess.run(
-        command,
-        cwd=project_paths.root,
-        capture_output=True,
-        text=True,
-        timeout=timeout_seconds,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=project_paths.root,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProviderRuntimeFailure(
+            "timeout",
+            "Claude CLI timed out after {0}s.".format(timeout_seconds),
+            timeout_seconds=timeout_seconds,
+            command=command,
+        ) from exc
     if result.returncode != 0:
-        raise RuntimeError(
-            "Claude CLI exited with status {0}: {1}".format(result.returncode, (result.stderr or "").strip() or "unknown error")
+        raise ProviderRuntimeFailure(
+            "nonzero_exit",
+            "Claude CLI exited with status {0}: {1}".format(
+                result.returncode,
+                (result.stderr or "").strip() or "unknown error",
+            ),
+            exit_code=result.returncode,
+            stderr=(result.stderr or "").strip(),
+            stdout=(result.stdout or "").strip(),
+            command=command,
         )
     return {
         "summary_text": (result.stdout or "").strip() or "Claude CLI completed without a final message.",
         "stdout": result.stdout or "",
         "stderr": result.stderr or "",
     }
+
+
+def _provider_failure_details(exc):
+    if isinstance(exc, ProviderRuntimeFailure):
+        return exc.kind, str(exc), dict(exc.details)
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return (
+            "timeout",
+            "Provider runtime timed out after {0}s.".format(exc.timeout),
+            {"timeout_seconds": exc.timeout, "command": exc.cmd},
+        )
+    return "runtime_error", str(exc), {}
 
 
 def _claude_cli_artifact_payload(provider, task_id, external_result):
@@ -432,9 +491,12 @@ def run_provider_task(connection, project_paths, project_id, agent_id, task_id, 
             artifact_existed_before_run=artifact_existed_before_run,
             original_artifact_bytes=original_artifact_bytes,
         )
-        failure_summary = "{0} adapter failed: {1}".format(provider["name"], exc)
+        failure_kind, failure_detail, failure_metadata = _provider_failure_details(exc)
+        failure_summary = "{0} adapter failed ({1}): {2}".format(provider["name"], failure_kind, failure_detail)
         if session_id is not None:
             try:
+                failure_activity_details = dict(extra_activity_details)
+                failure_activity_details.update(failure_metadata)
                 log_activity(
                     connection,
                     project_id=project_id,
@@ -448,9 +510,11 @@ def run_provider_task(connection, project_paths, project_id, agent_id, task_id, 
                         provider,
                         "session_failed",
                         session_id=session_id,
+                        failure_kind=failure_kind,
+                        failure_detail=failure_detail,
                         error=str(exc),
                         progress_pct=100,
-                        **extra_activity_details
+                        **failure_activity_details
                     ),
                 )
             except Exception:

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -130,7 +131,12 @@ class ProviderRuntimeTest(unittest.TestCase):
                         "completed_runs",
                         "failed_runs",
                         "last_run_at",
+                        "latest_failure_at",
+                        "latest_failure_kind",
+                        "nonzero_exit_failures",
+                        "runtime_failures",
                         "timed_out_runs",
+                        "timeout_failures",
                         "total_runs",
                     ]
                     for provider in payload["providers"]
@@ -1317,6 +1323,94 @@ class ProviderRuntimeTest(unittest.TestCase):
             self.assertTrue(os.path.exists(artifact_full_path))
             with open(artifact_full_path, "r", encoding="utf-8") as handle:
                 self.assertEqual(handle.read(), "preexisting claude artifact")
+
+    def test_providers_endpoint_classifies_codex_timeout_failures(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Codex Timeout Test", description="Codex timeout test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = self._enable_openai_codex_cli(connection)
+                goal_id = connection.execute("SELECT goal_id FROM goals ORDER BY created_at ASC LIMIT 1").fetchone()["goal_id"]
+                task_id = _insert_assigned_task(connection, project_id, goal_id, "agent_reviewer", "Run timed out Codex CLI adapter")
+                connection.commit()
+            finally:
+                connection.close()
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                with self.assertRaises(Exception):
+                    with mock.patch(
+                        "maas.services.provider_runtime.subprocess.run",
+                        side_effect=subprocess.TimeoutExpired(cmd=["codex", "exec"], timeout=120),
+                    ):
+                        run_provider_task(
+                            connection,
+                            project_paths=project_paths(tmpdir),
+                            project_id=project_id,
+                            agent_id="agent_reviewer",
+                            task_id=task_id,
+                            provider_type="openai_codex",
+                        )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            payload = client.get("/api/providers").json()
+            providers = {provider["id"]: provider for provider in payload["providers"]}
+            recent_run = providers["openai_codex"]["recent_runs"][0]
+            run_summary = providers["openai_codex"]["run_summary"]
+
+            self.assertEqual(recent_run["status"], "failed")
+            self.assertEqual(recent_run["execution_mode"], "codex_cli")
+            self.assertEqual(recent_run["external_runtime"], "codex_cli")
+            self.assertEqual(recent_run["failure_kind"], "timeout")
+            self.assertIn("timed out", recent_run["failure_detail"])
+            self.assertEqual(run_summary["timeout_failures"], 1)
+            self.assertEqual(run_summary["latest_failure_kind"], "timeout")
+
+    def test_providers_endpoint_classifies_claude_nonzero_exit_failures(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Claude Exit Test", description="Claude exit test", project_type="custom")
+            connection = connect(project_paths(tmpdir))
+            try:
+                project_id = self._enable_claude_code_cli(connection)
+                goal_id = connection.execute("SELECT goal_id FROM goals ORDER BY created_at ASC LIMIT 1").fetchone()["goal_id"]
+                task_id = _insert_assigned_task(connection, project_id, goal_id, "agent_researcher", "Run nonzero Claude CLI adapter")
+                connection.commit()
+            finally:
+                connection.close()
+
+            connection = connect(project_paths(tmpdir))
+            try:
+                with self.assertRaises(Exception):
+                    with mock.patch(
+                        "maas.services.provider_runtime.subprocess.run",
+                        return_value=mock.Mock(returncode=7, stdout="", stderr="permission denied"),
+                    ):
+                        run_provider_task(
+                            connection,
+                            project_paths=project_paths(tmpdir),
+                            project_id=project_id,
+                            agent_id="agent_researcher",
+                            task_id=task_id,
+                            provider_type="claude_code",
+                        )
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            payload = client.get("/api/providers").json()
+            providers = {provider["id"]: provider for provider in payload["providers"]}
+            recent_run = providers["claude_code"]["recent_runs"][0]
+            run_summary = providers["claude_code"]["run_summary"]
+
+            self.assertEqual(recent_run["status"], "failed")
+            self.assertEqual(recent_run["execution_mode"], "claude_cli")
+            self.assertEqual(recent_run["external_runtime"], "claude_cli")
+            self.assertEqual(recent_run["failure_kind"], "nonzero_exit")
+            self.assertIn("status 7", recent_run["failure_detail"])
+            self.assertEqual(run_summary["nonzero_exit_failures"], 1)
+            self.assertEqual(run_summary["latest_failure_kind"], "nonzero_exit")
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -250,7 +250,12 @@ const PROVIDERS_FALLBACK: ProvidersResponse = {
         failed_runs: 0,
         timed_out_runs: 0,
         cancelled_runs: 0,
-        last_run_at: null
+        last_run_at: null,
+        timeout_failures: 0,
+        nonzero_exit_failures: 0,
+        runtime_failures: 0,
+        latest_failure_kind: null,
+        latest_failure_at: null
       },
       recent_runs: [],
       notes: "Reference local runtime with normalized runtime phase reporting."
@@ -291,7 +296,12 @@ const PROVIDERS_FALLBACK: ProvidersResponse = {
         failed_runs: 0,
         timed_out_runs: 0,
         cancelled_runs: 0,
-        last_run_at: null
+        last_run_at: null,
+        timeout_failures: 0,
+        nonzero_exit_failures: 0,
+        runtime_failures: 0,
+        latest_failure_kind: null,
+        latest_failure_at: null
       },
       recent_runs: [],
       notes: "Simulated local adapter with normalized runtime phase reporting."
@@ -332,7 +342,12 @@ const PROVIDERS_FALLBACK: ProvidersResponse = {
         failed_runs: 0,
         timed_out_runs: 0,
         cancelled_runs: 0,
-        last_run_at: null
+        last_run_at: null,
+        timeout_failures: 0,
+        nonzero_exit_failures: 0,
+        runtime_failures: 0,
+        latest_failure_kind: null,
+        latest_failure_at: null
       },
       recent_runs: [],
       notes: "Simulated API-style adapter with normalized runtime phase reporting."

--- a/web/src/pages/ProvidersPage.tsx
+++ b/web/src/pages/ProvidersPage.tsx
@@ -53,6 +53,13 @@ function formatRuntimeControls(provider: ProviderStatusItem) {
   return rows.join(" | ");
 }
 
+function formatFailureKind(kind?: string | null) {
+  if (!kind) {
+    return null;
+  }
+  return kind.replace(/_/g, " ");
+}
+
 export function ProvidersPage() {
   const [providers, setProviders] = useState<ProvidersResponse | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -236,8 +243,21 @@ export function ProvidersPage() {
                       Runs: {provider.run_summary?.total_runs ?? 0} total | {provider.run_summary?.completed_runs ?? 0} completed |{" "}
                       {provider.run_summary?.failed_runs ?? 0} failed | {provider.run_summary?.timed_out_runs ?? 0} timed out
                     </p>
+                    <p>
+                      Failure breakdown: {provider.run_summary?.timeout_failures ?? 0} timeout |{" "}
+                      {provider.run_summary?.nonzero_exit_failures ?? 0} non-zero exit |{" "}
+                      {provider.run_summary?.runtime_failures ?? 0} runtime
+                    </p>
                     {provider.run_summary?.last_run_at ? (
                       <p>Last run: {new Date(provider.run_summary.last_run_at).toLocaleString()}</p>
+                    ) : null}
+                    {provider.run_summary?.latest_failure_kind ? (
+                      <p>
+                        Latest failure: {formatFailureKind(provider.run_summary.latest_failure_kind)}
+                        {provider.run_summary.latest_failure_at
+                          ? ` | ${new Date(provider.run_summary.latest_failure_at).toLocaleString()}`
+                          : ""}
+                      </p>
                     ) : null}
                     <p>Available modes: {(provider.available_execution_modes ?? []).join(", ") || "local_simulation"}</p>
                     {runtimeControls ? <p>{runtimeControls}</p> : null}
@@ -262,7 +282,10 @@ export function ProvidersPage() {
                       <p key={run.session_id}>
                         Recent run: {run.task_title ?? run.task_id ?? run.session_id} | {run.status}
                         {run.agent_name ? ` | ${run.agent_name}` : ""}
+                        {run.execution_mode ? ` | ${run.execution_mode}` : ""}
+                        {run.failure_kind ? ` | ${formatFailureKind(run.failure_kind)}` : ""}
                         {run.started_at ? ` | ${new Date(run.started_at).toLocaleString()}` : ""}
+                        {run.failure_detail ? ` | ${run.failure_detail}` : ""}
                       </p>
                     ))}
                   </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -537,6 +537,11 @@ export interface ProviderRunSummary {
   timed_out_runs: number;
   cancelled_runs: number;
   last_run_at?: string | null;
+  timeout_failures: number;
+  nonzero_exit_failures: number;
+  runtime_failures: number;
+  latest_failure_kind?: string | null;
+  latest_failure_at?: string | null;
 }
 
 export interface ProviderRunItem {
@@ -550,6 +555,10 @@ export interface ProviderRunItem {
   status_message?: string | null;
   started_at: string;
   ended_at?: string | null;
+  execution_mode?: string | null;
+  external_runtime?: string | null;
+  failure_kind?: string | null;
+  failure_detail?: string | null;
 }
 
 export interface ProviderRunTarget {


### PR DESCRIPTION
## Done on main
- [x] Real local Claude and Codex CLI execution paths
- [x] Provider mode switching, editable runtime settings, and manual provider runs
- [x] Provider visibility with run summaries and recent runs

## Working in this PR
- [ ] Normalize provider runtime failure kinds across live provider paths
- [ ] Distinguish timeout, nonzero exit, and generic runtime failures in provider activity
- [ ] Surface failure kind and detail in provider recent runs and provider health summary
- [ ] Show the normalized provider failure state in the Providers view
- [ ] Add focused regression coverage for live-provider timeout and nonzero-exit failures

## Still to do
- [ ] Richer provider preflight and executable discovery
- [ ] Remote or hosted provider execution modes beyond local CLI paths
- [ ] Brownfield onboarding and multi-project support

## Validation
- python3 -m py_compile src/maas/services/provider_runtime.py src/maas/providers.py tests/test_provider_runtime.py
- PYTHONPATH=src python3 -m unittest tests.test_provider_runtime
- git diff --check
