### PR TITLE
Add brownfield codebase map and planning

### DIFF
--- a/docs/implementation/08-brownfield-and-multi-project.md
+++ b/docs/implementation/08-brownfield-and-multi-project.md
@@ -2,14 +2,14 @@
 
 ## Status On `main`
 
-- [ ] Batch 8 has not started on `main`.
+- [ ] Batch 8 is partially started on `main` through brownfield repo detection, onboarding approval gating, imported workflow and repo-area backlog seeding, and Overview visibility.
 
 ## Still To Do On `main`
 
-- [ ] Brownfield discovery pipeline
-- [ ] Reviewed overlay onboarding
+- [ ] Deeper brownfield codebase mapping and repo-derived planning
 - [ ] Multi-project routing
-- [ ] Dashboard and plugin extensions
+- [ ] Dashboard and plugin extensions for cross-project operation
+- [ ] Stronger runtime isolation for imported repos
 
 ## Non-Goals
 
@@ -18,5 +18,5 @@
 
 ## Acceptance Checklist
 
-- [ ] Brownfield fixture produces a reviewable understanding artifact
+- [x] Brownfield fixture produces a reviewable understanding artifact
 - [ ] Multi-project API routing isolates project data correctly

--- a/src/maas/services/bootstrap.py
+++ b/src/maas/services/bootstrap.py
@@ -91,6 +91,15 @@ WORKFLOW_SIGNAL_LABELS = {
     "github_actions": "GitHub Actions workflow",
 }
 
+CODEBASE_AREA_LABELS = {
+    "source": "source area",
+    "tests": "test surface",
+    "docs": "docs surface",
+    "automation": "automation surface",
+    "config": "config surface",
+    "mixed": "repo area",
+}
+
 
 def default_project_name(project_root):
     return os.path.basename(os.path.abspath(project_root)) or "maas-project"
@@ -250,6 +259,66 @@ def _top_entries(counts, limit=4):
     return ordered[:limit]
 
 
+def _classify_codebase_area(name, discovery):
+    lowered = (name or "").lower()
+    if name in (discovery.get("docs_roots") or []) or lowered in {"docs", "doc"}:
+        return "docs"
+    if name in (discovery.get("test_roots") or []) or "test" in lowered or lowered == "spec":
+        return "tests"
+    if lowered in {"scripts", "tools", ".github"}:
+        return "automation"
+    if lowered in {"config", "configs"}:
+        return "config"
+    if lowered in {"src", "app", "apps", "api", "server", "client", "web", "lib", "libs", "pkg", "packages", "services"}:
+        return "source"
+    return "mixed"
+
+
+def _build_codebase_map(discovery):
+    codebase_map = []
+    for item in discovery.get("top_level_dirs", []):
+        kind = _classify_codebase_area(item["name"], discovery)
+        summary_parts = [
+            "{language} stack".format(language=item["primary_language"]),
+            "{count} files".format(count=item["file_count"]),
+        ]
+        if kind == "tests":
+            summary_parts.append("test entrypoint area")
+        elif kind == "docs":
+            summary_parts.append("operator-facing docs area")
+        elif kind == "automation":
+            summary_parts.append("automation and workflow area")
+        elif kind == "source":
+            summary_parts.append("primary implementation area")
+        codebase_map.append(
+            {
+                "name": item["name"],
+                "path": item["name"],
+                "kind": kind,
+                "primary_language": item["primary_language"],
+                "file_count": item["file_count"],
+                "summary": ", ".join(summary_parts),
+            }
+        )
+        if len(codebase_map) >= 4:
+            break
+
+    if not codebase_map and discovery.get("total_files"):
+        codebase_map.append(
+            {
+                "name": "repository_root",
+                "path": ".",
+                "kind": "mixed",
+                "primary_language": discovery.get("primary_language") or "unknown",
+                "file_count": discovery.get("total_files") or 0,
+                "summary": "root-level repo layout with {count} files".format(
+                    count=discovery.get("total_files") or 0
+                ),
+            }
+        )
+    return codebase_map
+
+
 def discover_brownfield_project(project_root):
     project_root = os.path.abspath(project_root)
     discovery = {
@@ -397,6 +466,7 @@ def discover_brownfield_project(project_root):
         unique_signals.append(signal)
     discovery["workflow_signals"] = unique_signals[:10]
     discovery["scripts"] = [signal["name"] for signal in discovery["workflow_signals"] if signal["kind"] in {"make_target", "npm_script", "python_script"}][:6]
+    discovery["codebase_map"] = _build_codebase_map(discovery)
     return discovery
 
 
@@ -416,6 +486,16 @@ def build_understanding_markdown(config, mode="greenfield", discovery=None):
             "{kind}:{name}".format(kind=item["kind"], name=item["name"])
             for item in discovery["workflow_signals"]
         ) or "none detected"
+        codebase_map = "\n".join(
+            "- {name} ({kind}, {language}, {count} files): {summary}".format(
+                name=item["name"],
+                kind=CODEBASE_AREA_LABELS.get(item["kind"], item["kind"]),
+                language=item["primary_language"],
+                count=item["file_count"],
+                summary=item["summary"],
+            )
+            for item in discovery.get("codebase_map", [])
+        ) or "- none detected"
         docs = ", ".join(discovery["docs_roots"]) or "none detected"
         tests = ", ".join(discovery["test_roots"]) or "none detected"
         readme_excerpt = discovery["readme_excerpt"] or "No README excerpt available."
@@ -442,6 +522,8 @@ def build_understanding_markdown(config, mode="greenfield", discovery=None):
 ## Workflow Signals
 
 - Detected commands and automation: {workflows}
+- Imported codebase map:
+{codebase_map}
 - Initial README excerpt:
 
 {readme_excerpt}
@@ -469,6 +551,7 @@ def build_understanding_markdown(config, mode="greenfield", discovery=None):
             docs=docs,
             tests=tests,
             workflows=workflows,
+            codebase_map=codebase_map,
             readme_excerpt=readme_excerpt,
         )
     return """# Project Understanding
@@ -519,6 +602,17 @@ def build_discovery_summary(discovery):
             for item in discovery["workflow_signals"][:5]
         ],
         "repo_areas": [item["name"] for item in discovery["top_level_dirs"][:4]],
+        "codebase_map": [
+            {
+                "name": item["name"],
+                "path": item.get("path") or item["name"],
+                "kind": item["kind"],
+                "primary_language": item["primary_language"],
+                "file_count": item["file_count"],
+                "summary": item.get("summary") or "",
+            }
+            for item in discovery.get("codebase_map", [])[:4]
+        ],
     }
 
 
@@ -545,6 +639,18 @@ def _operator_workflow_signals(discovery):
         seen.add(key)
         operator_signals.append(item)
     return operator_signals[:3]
+
+
+def _operator_codebase_entries(discovery):
+    entries = []
+    seen = set()
+    for item in discovery.get("codebase_map", []):
+        key = item["name"]
+        if key in seen:
+            continue
+        seen.add(key)
+        entries.append(item)
+    return entries[:2]
 
 
 def build_brownfield_task_specs(discovery):
@@ -582,15 +688,19 @@ def build_brownfield_task_specs(discovery):
         workflow_priority -= 2
 
     repo_area_priority = 88
-    for item in discovery.get("top_level_dirs", [])[:2]:
+    for item in _operator_codebase_entries(discovery):
+        kind_label = CODEBASE_AREA_LABELS.get(item["kind"], "repo area")
         task_specs.append(
             (
                 "blocked",
-                "Map imported repo area: {name}".format(name=item["name"]),
+                "Map imported {kind}: {name}".format(kind=kind_label, name=item["name"]),
                 "agent_allocator",
                 repo_area_priority,
-                "Turn the imported repo area `{name}` into an operator-visible ownership/workflow area.".format(
-                    name=item["name"]
+                "Turn the imported {kind} `{name}` into an operator-visible ownership/workflow area using the discovered {language} stack and {count} files.".format(
+                    kind=kind_label,
+                    name=item["name"],
+                    language=item["primary_language"],
+                    count=item["file_count"],
                 ),
                 BROWNFIELD_PENDING_REVIEW_STATE,
                 0,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -104,10 +104,23 @@ lint = "example:main"
                 config["onboarding"]["discovery_summary"]["workflow_details"][0]["detail"],
             )
             self.assertIn("src", config["onboarding"]["discovery_summary"]["repo_areas"])
+            self.assertEqual(
+                config["onboarding"]["discovery_summary"]["codebase_map"][0]["name"],
+                "src",
+            )
+            self.assertEqual(
+                config["onboarding"]["discovery_summary"]["codebase_map"][0]["kind"],
+                "source",
+            )
+            self.assertEqual(
+                config["onboarding"]["discovery_summary"]["codebase_map"][1]["kind"],
+                "tests",
+            )
             self.assertIn("Review imported project understanding", task_titles)
             self.assertIn("Validate imported workflow: lint", task_titles)
             self.assertIn("Validate imported workflow: test", task_titles)
-            self.assertIn("Map imported repo area: src", task_titles)
+            self.assertIn("Map imported source area: src", task_titles)
+            self.assertIn("Map imported test surface: tests", task_titles)
             self.assertIn("Align runtime and provider settings with existing tooling", task_titles)
 
     def test_bootstrap_auto_detects_brownfield_from_hidden_repo_signals(self):
@@ -170,6 +183,8 @@ lint = "example:main"
             self.assertTrue(
                 any(signal.get("path") == ".github/workflows/invalid.yml" for signal in discovery["workflow_signals"])
             )
+            self.assertEqual(discovery["codebase_map"][0]["name"], ".github")
+            self.assertEqual(discovery["codebase_map"][0]["kind"], "automation")
 
     def test_bootstrap_keeps_top_level_directories_when_root_files_dominate(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -93,6 +93,16 @@ lint = "example:main"
                 len(overview_payload["onboarding"]["discovery_summary"]["workflow_details"]),
                 1,
             )
+            self.assertGreaterEqual(
+                len(overview_payload["onboarding"]["discovery_summary"]["codebase_map"]),
+                1,
+            )
+            self.assertTrue(
+                any(
+                    item["name"] == "src"
+                    for item in overview_payload["onboarding"]["discovery_summary"]["codebase_map"]
+                )
+            )
             self.assertIn(
                 "src",
                 overview_payload["onboarding"]["discovery_summary"]["repo_areas"],

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -40,7 +40,8 @@ const OVERVIEW_FALLBACK: OverviewResponse = {
     discovery_summary: {
       workflow_labels: [],
       workflow_details: [],
-      repo_areas: []
+      repo_areas: [],
+      codebase_map: []
     },
     review_task_id: null,
     review_task_status: null,

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -216,6 +216,26 @@ export function OverviewPage() {
                     </div>
                   </div>
                 ) : null}
+                {(overview.onboarding.discovery_summary.codebase_map?.length ?? 0) > 0 ? (
+                  <div className="data-list__item">
+                    <div>
+                      <strong>Imported codebase map</strong>
+                      {overview.onboarding.discovery_summary.codebase_map?.map((item) => (
+                        <p key={`${item.name}-${item.path ?? ""}`}>
+                          <strong>{item.name}</strong>
+                          {` · ${item.kind.replaceAll("_", " ")}`}
+                          {item.path ? ` · ${item.path}` : ""}
+                          {` · ${item.primary_language}`}
+                          {` · ${item.file_count} files`}
+                          {item.summary ? ` · ${item.summary}` : ""}
+                        </p>
+                      ))}
+                    </div>
+                    <div className="data-list__meta">
+                      <span>{overview.onboarding.discovery_summary.codebase_map?.length ?? 0} mapped areas</span>
+                    </div>
+                  </div>
+                ) : null}
                 {overview.onboarding.reviewed_at ? (
                 <div className="data-list__item">
                   <div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -124,6 +124,14 @@ export interface OverviewOnboarding {
       detail?: string;
     }>;
     repo_areas?: string[];
+    codebase_map?: Array<{
+      name: string;
+      path?: string;
+      kind: string;
+      primary_language: string;
+      file_count: number;
+      summary?: string;
+    }>;
   };
   review_task_id?: string | null;
   review_task_status?: string | null;


### PR DESCRIPTION
## Done on main
- [x] Brownfield `maas init` can detect an existing repo, require explicit onboarding approval, and seed imported workflow plus repo-area tasks
- [x] Overview already shows brownfield onboarding state, discovery summary labels, and imported workflow details
- [ ] `main` still lacks a first-class brownfield codebase map and repo-derived planning tasks

## Working in this PR
- [x] Add a structured brownfield `codebase_map` with area kind, path, primary language, file count, and summary
- [x] Persist that codebase map into onboarding discovery summary and the brownfield understanding artifact
- [x] Seed more concrete imported planning tasks from the codebase map instead of generic repo-area mapping titles
- [x] Show the imported codebase map in the Overview brownfield onboarding panel
- [x] Add focused bootstrap and dashboard coverage and sync the Batch 8 implementation doc to the actual `main` baseline

## Still to do
- [ ] `#76` Multi-project foundation
- [ ] `#77` Runtime sandbox and isolation hardening
- [ ] `#78` Adaptive replanning and scheduler feedback
- [ ] `#79` Policy-driven self-healing and DLQ automation
- [ ] `#80` Broader provider/runtime coverage
