### PR TITLE
Make supervisor orchestration project-aware

### DIFF
--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -134,10 +134,12 @@ class AssignTaskRequest(BaseModel):
 class AllocateTasksRequest(BaseModel):
     actor_id: str = "system_allocator"
     limit: int = None
+    project_id: Optional[str] = None
 
 
 class SupervisorRunRequest(BaseModel):
     allocate_limit: int = None
+    project_id: Optional[str] = None
 
 
 class EscalationRequestPayload(BaseModel):
@@ -385,10 +387,10 @@ def create_app(project_root="."):
             connection.close()
 
     @app.get("/api/tasks/ready")
-    def tasks_ready():
+    def tasks_ready(project_id: str = None):
         connection = connect(paths)
         try:
-            return {"tasks": resolve_ready_tasks(connection)}
+            return {"tasks": resolve_ready_tasks(connection, project_id=_selected_project_id(connection, project_id))}
         finally:
             connection.close()
 
@@ -1027,10 +1029,14 @@ def create_app(project_root="."):
             connection.close()
 
     @app.post("/api/tasks/actions/refresh-ready")
-    def task_refresh_ready_action():
+    def task_refresh_ready_action(project_id: str = None):
         connection = connect(paths)
         try:
-            return {"changed": refresh_ready_tasks(connection), "tasks": resolve_ready_tasks(connection)}
+            scoped_project_id = _selected_project_id(connection, project_id)
+            return {
+                "changed": refresh_ready_tasks(connection, project_id=scoped_project_id),
+                "tasks": resolve_ready_tasks(connection, project_id=scoped_project_id),
+            }
         finally:
             connection.close()
 
@@ -1048,7 +1054,13 @@ def create_app(project_root="."):
     def task_allocate_ready_action(payload: AllocateTasksRequest):
         connection = connect(paths)
         try:
-            return allocate_ready_tasks(connection, actor_id=payload.actor_id, limit=payload.limit)
+            scoped_project_id = _selected_project_id(connection, payload.project_id)
+            return allocate_ready_tasks(
+                connection,
+                actor_id=payload.actor_id,
+                limit=payload.limit,
+                project_id=scoped_project_id,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
         finally:
@@ -1083,7 +1095,8 @@ def create_app(project_root="."):
         connection = connect(paths)
         try:
             limit = None if payload is None else payload.allocate_limit
-            return run_supervisor_once(connection, allocate_limit=limit, project_paths=paths)
+            scoped_project_id = None if payload is None else _selected_project_id(connection, payload.project_id)
+            return run_supervisor_once(connection, allocate_limit=limit, project_paths=paths, project_id=scoped_project_id)
         finally:
             connection.close()
 

--- a/src/maas/cli.py
+++ b/src/maas/cli.py
@@ -61,6 +61,7 @@ def build_parser():
     supervisor_parser.add_argument("--project-root", default=".")
     supervisor_parser.add_argument("--once", action="store_true")
     supervisor_parser.add_argument("--allocate-limit", type=int)
+    supervisor_parser.add_argument("--project-id")
 
     board_parser = subparsers.add_parser("board")
     board_parser.add_argument("--project-root", default=".")
@@ -327,7 +328,12 @@ def command_supervisor(args):
     while True:
         connection = connect(paths)
         try:
-            findings = run_supervisor_once(connection, allocate_limit=args.allocate_limit, project_paths=paths)
+            findings = run_supervisor_once(
+                connection,
+                allocate_limit=args.allocate_limit,
+                project_paths=paths,
+                project_id=args.project_id,
+            )
             print(json.dumps(findings, indent=2))
         finally:
             connection.close()

--- a/src/maas/services/scheduler.py
+++ b/src/maas/services/scheduler.py
@@ -113,31 +113,37 @@ def _cooldown_active(value):
     return next_retry_at > datetime.utcnow()
 
 
-def _agent_rows(connection):
-    return connection.execute(
-        """
+def _agent_rows(connection, project_id=None):
+    query = """
         SELECT agent_id, project_id, role, display_name, status, current_task_id
         FROM agents
-        ORDER BY display_name ASC
-        """
-    ).fetchall()
+    """
+    parameters = []
+    if project_id is not None:
+        query += "\nWHERE project_id = ?"
+        parameters.append(project_id)
+    query += "\nORDER BY display_name ASC"
+    return connection.execute(query, tuple(parameters)).fetchall()
 
 
 def _eligible_idle_agents(agent_rows):
     return [row for row in agent_rows if row["status"] == "idle" and row["current_task_id"] is None]
 
 
-def resolve_ready_tasks(connection):
-    rows = connection.execute(
-        """
+def resolve_ready_tasks(connection, project_id=None):
+    query = """
         SELECT task_id, title, description, priority, status, retry_count, assigned_agent_id, created_at, next_retry_at, next_retry_reason
         FROM tasks
         WHERE status IN ('planned', 'assigned', 'ready')
-        ORDER BY priority DESC, created_at ASC
-        """
-    ).fetchall()
+    """
+    parameters = []
+    if project_id is not None:
+        query += "\n  AND project_id = ?"
+        parameters.append(project_id)
+    query += "\nORDER BY priority DESC, created_at ASC"
+    rows = connection.execute(query, tuple(parameters)).fetchall()
     failure_rollup = _task_failure_rollup(connection, [row["task_id"] for row in rows])
-    agent_rows = _agent_rows(connection)
+    agent_rows = _agent_rows(connection, project_id=project_id)
     ready = []
     for row in rows:
         item = dict(row)
@@ -179,14 +185,17 @@ def resolve_ready_tasks(connection):
     return ranked_ready
 
 
-def refresh_ready_tasks(connection, commit=True):
-    task_rows = connection.execute(
-        """
+def refresh_ready_tasks(connection, commit=True, project_id=None):
+    query = """
         SELECT task_id, status, assigned_agent_id, review_state, next_retry_at, next_retry_reason
         FROM tasks
         WHERE status IN ('planned', 'assigned', 'ready', 'blocked')
-        """
-    ).fetchall()
+    """
+    parameters = []
+    if project_id is not None:
+        query += "\n  AND project_id = ?"
+        parameters.append(project_id)
+    task_rows = connection.execute(query, tuple(parameters)).fetchall()
     changed = []
     for row in task_rows:
         blocked_by_dependency = _task_is_blocked(connection, row["task_id"])
@@ -559,14 +568,16 @@ def describe_task_scheduler(task_row, decision=None):
 
 
 def _candidate_tasks_for_agent(connection, agent_row):
-    refresh_ready_tasks(connection)
+    refresh_ready_tasks(connection, project_id=agent_row["project_id"])
     rows = connection.execute(
         """
         SELECT task_id, project_id, title, description, status, priority, retry_count, assigned_agent_id, created_at
         FROM tasks
-        WHERE status IN ('ready', 'assigned')
+        WHERE project_id = ?
+          AND status IN ('ready', 'assigned')
         ORDER BY priority DESC, created_at ASC
-        """
+        """,
+        (agent_row["project_id"],),
     ).fetchall()
     failure_rollup = _task_failure_rollup(connection, [row["task_id"] for row in rows])
 
@@ -698,15 +709,18 @@ def assign_next_task(connection, agent_id, actor_id="system_allocator"):
     }
 
 
-def allocate_ready_tasks(connection, actor_id="system_allocator", limit=None):
-    idle_agents = connection.execute(
-        """
+def allocate_ready_tasks(connection, actor_id="system_allocator", limit=None, project_id=None):
+    query = """
         SELECT agent_id
         FROM agents
         WHERE status = 'idle' AND current_task_id IS NULL
-        ORDER BY display_name ASC
-        """
-    ).fetchall()
+    """
+    parameters = []
+    if project_id is not None:
+        query += "\n  AND project_id = ?"
+        parameters.append(project_id)
+    query += "\nORDER BY display_name ASC"
+    idle_agents = connection.execute(query, tuple(parameters)).fetchall()
 
     allocations = []
     new_assignment_count = 0

--- a/src/maas/supervisor.py
+++ b/src/maas/supervisor.py
@@ -12,7 +12,7 @@ from maas.services.failure_memory import (
     record_failure,
     resolve_repeated_failure_alerts,
 )
-from maas.services.projects import resolve_project_id
+from maas.services.projects import list_projects, resolve_project_id
 from maas.services.recovery_policy import (
     fetch_auto_recovery_candidate_tasks,
     fetch_project_recovery_policy,
@@ -220,18 +220,20 @@ def _maybe_route_timed_out_task_to_dlq(connection, project_id, task_id, actor_id
     return {"task_id": task_id, "dlq_id": dlq_id, "retry_limit": retry_limit, "retry_count": task["retry_count"]}
 
 
-def _handle_stale_sessions(connection, stale_after_seconds, project_paths=None):
+def _handle_stale_sessions(connection, stale_after_seconds, project_paths=None, project_id=None):
     stale_before = datetime.utcnow() - timedelta(seconds=stale_after_seconds)
-    stale_rows = connection.execute(
-        """
+    query = """
         SELECT session_id, project_id, agent_id, task_id
         FROM sessions
         WHERE status = 'active'
           AND last_heartbeat_at IS NOT NULL
           AND last_heartbeat_at < ?
-        """,
-        (stale_before.strftime("%Y-%m-%d %H:%M:%S"),),
-    ).fetchall()
+    """
+    parameters = [stale_before.strftime("%Y-%m-%d %H:%M:%S")]
+    if project_id is not None:
+        query += "\n  AND project_id = ?"
+        parameters.append(project_id)
+    stale_rows = connection.execute(query, tuple(parameters)).fetchall()
 
     findings = []
     for row in stale_rows:
@@ -391,17 +393,17 @@ def _handle_stale_sessions(connection, stale_after_seconds, project_paths=None):
     return findings
 
 
-def _auto_recover_blocked_tasks(connection):
-    project_id = resolve_project_id(connection)
-    if project_id is None:
+def _auto_recover_blocked_tasks(connection, project_id=None):
+    resolved_project_id = resolve_project_id(connection, project_id) if project_id is not None else resolve_project_id(connection)
+    if resolved_project_id is None:
         return []
 
-    policy = fetch_project_recovery_policy(connection, project_id)
+    policy = fetch_project_recovery_policy(connection, resolved_project_id)
     if not policy["auto_recover_blocked_tasks"]:
         return []
 
     findings = []
-    for candidate in fetch_auto_recovery_candidate_tasks(connection, project_id=project_id, limit=None):
+    for candidate in fetch_auto_recovery_candidate_tasks(connection, project_id=resolved_project_id, limit=None):
         task = connection.execute(
             """
             SELECT task_id, project_id, assigned_agent_id, status, review_state
@@ -430,26 +432,86 @@ def _auto_recover_blocked_tasks(connection):
     return findings
 
 
-def run_supervisor_once(connection, stale_after_seconds=HEARTBEAT_STALE_SECONDS, allocate_limit=None, project_paths=None):
-    ready_changes = refresh_ready_tasks(connection)
-    allocation_result = allocate_ready_tasks(connection, actor_id="system_supervisor", limit=allocate_limit)
-    stale_sessions = _handle_stale_sessions(connection, stale_after_seconds, project_paths=project_paths)
-    auto_recovered_tasks = _auto_recover_blocked_tasks(connection)
-    if any(item.get("auto_retried") for item in stale_sessions) or auto_recovered_tasks:
-        ready_changes.extend(refresh_ready_tasks(connection))
-        remaining_limit = None
-        if allocate_limit is not None:
-            remaining_limit = max(allocate_limit - allocation_result["assigned_count"], 0)
-        retry_allocations = allocate_ready_tasks(connection, actor_id="system_supervisor", limit=remaining_limit)
-        allocation_result = {
-            "allocations": allocation_result["allocations"] + retry_allocations["allocations"],
-            "assigned_count": allocation_result["assigned_count"] + retry_allocations["assigned_count"],
-        }
+def _active_project_ids(connection, project_id=None):
+    if project_id is not None:
+        resolved_project_id = resolve_project_id(connection, project_id)
+        if resolved_project_id is None:
+            raise ValueError("project not found")
+        return [resolved_project_id]
+    return [item["project_id"] for item in list_projects(connection, include_archived=False)]
+
+
+def run_supervisor_once(
+    connection,
+    stale_after_seconds=HEARTBEAT_STALE_SECONDS,
+    allocate_limit=None,
+    project_paths=None,
+    project_id=None,
+):
+    remaining_limit = allocate_limit
+    project_runs = []
+    ready_changes = []
+    allocations = []
+    stale_sessions = []
+    auto_recovered_tasks = []
+
+    for scoped_project_id in _active_project_ids(connection, project_id=project_id):
+        project_ready_changes = refresh_ready_tasks(connection, commit=False, project_id=scoped_project_id)
+        project_allocation_result = allocate_ready_tasks(
+            connection,
+            actor_id="system_supervisor",
+            limit=remaining_limit,
+            project_id=scoped_project_id,
+        )
+        project_stale_sessions = _handle_stale_sessions(
+            connection,
+            stale_after_seconds,
+            project_paths=project_paths,
+            project_id=scoped_project_id,
+        )
+        project_auto_recovered_tasks = _auto_recover_blocked_tasks(connection, project_id=scoped_project_id)
+        if any(item.get("auto_retried") for item in project_stale_sessions) or project_auto_recovered_tasks:
+            project_ready_changes.extend(
+                refresh_ready_tasks(connection, commit=False, project_id=scoped_project_id)
+            )
+            retry_limit = remaining_limit
+            if retry_limit is not None:
+                retry_limit = max(retry_limit - project_allocation_result["assigned_count"], 0)
+            retry_allocations = allocate_ready_tasks(
+                connection,
+                actor_id="system_supervisor",
+                limit=retry_limit,
+                project_id=scoped_project_id,
+            )
+            project_allocation_result = {
+                "allocations": project_allocation_result["allocations"] + retry_allocations["allocations"],
+                "assigned_count": project_allocation_result["assigned_count"] + retry_allocations["assigned_count"],
+            }
+
+        if remaining_limit is not None:
+            remaining_limit = max(remaining_limit - project_allocation_result["assigned_count"], 0)
+
+        ready_changes.extend(project_ready_changes)
+        allocations.extend(project_allocation_result["allocations"])
+        stale_sessions.extend(project_stale_sessions)
+        auto_recovered_tasks.extend(project_auto_recovered_tasks)
+        project_runs.append(
+            {
+                "project_id": scoped_project_id,
+                "ready_changes": project_ready_changes,
+                "allocations": project_allocation_result["allocations"],
+                "assigned_count": project_allocation_result["assigned_count"],
+                "stale_sessions": project_stale_sessions,
+                "auto_recovered_tasks": project_auto_recovered_tasks,
+            }
+        )
+
     connection.commit()
     return {
         "ready_changes": ready_changes,
-        "allocations": allocation_result["allocations"],
-        "assigned_count": allocation_result["assigned_count"],
+        "allocations": allocations,
+        "assigned_count": len([item for item in allocations if item.get("assigned")]),
         "stale_sessions": stale_sessions,
         "auto_recovered_tasks": auto_recovered_tasks,
+        "project_runs": project_runs,
     }

--- a/tests/test_scheduler_api.py
+++ b/tests/test_scheduler_api.py
@@ -9,11 +9,90 @@ from maas.api import create_app
 from maas.db import connect
 from maas.ids import generate_id
 from maas.services.bootstrap import bootstrap_project
+from maas.services.projects import create_project
 from maas.services.lifecycle import end_session
 from maas.services.scheduler import assign_next_task, evaluate_task, refresh_ready_tasks, resolve_ready_tasks
 
 
 class SchedulerApiTest(unittest.TestCase):
+    def test_assign_next_task_does_not_cross_project_boundaries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Scheduler Project Scope Test",
+                description="Scheduler project scope test",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                primary_project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                second_project = create_project(
+                    connection,
+                    result["paths"],
+                    actor_id="agent_allocator",
+                    name="Second Project",
+                    description="secondary",
+                    project_type="custom",
+                    mode="greenfield",
+                )
+                second_project_id = second_project["project"]["project_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'done'
+                    WHERE project_id = ?
+                      AND status IN ('planned', 'ready', 'assigned', 'blocked')
+                    """,
+                    (second_project_id,),
+                )
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'done'
+                    WHERE project_id = ?
+                      AND title != 'Define project workspace contracts'
+                      AND status IN ('planned', 'ready', 'assigned', 'blocked')
+                    """,
+                    (primary_project_id,),
+                )
+                target_task_id = connection.execute(
+                    """
+                    SELECT task_id
+                    FROM tasks
+                    WHERE project_id = ? AND title = 'Define project workspace contracts'
+                    """,
+                    (primary_project_id,),
+                ).fetchone()["task_id"]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'ready',
+                        assigned_agent_id = NULL
+                    WHERE task_id = ?
+                    """,
+                    (target_task_id,),
+                )
+                second_agent_id = connection.execute(
+                    """
+                    SELECT agent_id
+                    FROM agents
+                    WHERE project_id = ? AND role = 'researcher'
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """,
+                    (second_project_id,),
+                ).fetchone()["agent_id"]
+                connection.commit()
+
+                result_payload = assign_next_task(connection, second_agent_id, actor_id="agent_allocator")
+                primary_ready = resolve_ready_tasks(connection, project_id=primary_project_id)
+            finally:
+                connection.close()
+
+            self.assertFalse(result_payload["assigned"])
+            self.assertIsNone(result_payload["task_id"])
+            self.assertEqual([item["task_id"] for item in primary_ready], [target_task_id])
+
     def test_assign_next_task_returns_explicit_scheduler_score(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = bootstrap_project(tmpdir, name="Scheduler Score Test", description="Scheduler score test", project_type="custom")

--- a/tests/test_supervisor_api.py
+++ b/tests/test_supervisor_api.py
@@ -11,7 +11,7 @@ from maas.services.bootstrap import bootstrap_project
 from maas.ids import generate_id
 from maas.services.alerts import fetch_alerts
 from maas.services.lifecycle import end_session, heartbeat, produce_artifact
-from maas.services.projects import resolve_project_id
+from maas.services.projects import create_project, resolve_project_id
 from maas.supervisor import run_supervisor_once
 
 
@@ -715,6 +715,96 @@ class SupervisorApiTest(unittest.TestCase):
             self.assertIn("ready_changes", payload)
             self.assertIn("allocations", payload)
             self.assertEqual(payload["assigned_count"], 1)
+            self.assertIn("project_runs", payload)
+            self.assertEqual(len(payload["project_runs"]), 1)
+
+    def test_supervisor_api_can_scope_run_to_selected_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Supervisor Scoped API Test",
+                description="Supervisor scoped API test",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                primary_project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                second_project_id = create_project(
+                    connection,
+                    result["paths"],
+                    actor_id="agent_allocator",
+                    name="Second Project",
+                    description="secondary",
+                    project_type="custom",
+                    mode="greenfield",
+                )["project"]["project_id"]
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            response = client.post(
+                "/api/supervisor/run",
+                json={"allocate_limit": 2, "project_id": primary_project_id},
+            )
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+
+            connection = connect(result["paths"])
+            try:
+                primary_assigned = connection.execute(
+                    "SELECT COUNT(*) AS count FROM tasks WHERE project_id = ? AND status = 'assigned'",
+                    (primary_project_id,),
+                ).fetchone()["count"]
+                second_assigned = connection.execute(
+                    "SELECT COUNT(*) AS count FROM tasks WHERE project_id = ? AND status = 'assigned'",
+                    (second_project_id,),
+                ).fetchone()["count"]
+            finally:
+                connection.close()
+
+            self.assertEqual(payload["assigned_count"], 2)
+            self.assertEqual([item["project_id"] for item in payload["project_runs"]], [primary_project_id])
+            self.assertGreater(primary_assigned, 0)
+            self.assertEqual(second_assigned, 0)
+
+    def test_supervisor_default_run_iterates_all_active_projects(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = bootstrap_project(
+                tmpdir,
+                name="Supervisor Multi Project Test",
+                description="Supervisor multi project test",
+                project_type="custom",
+            )
+            connection = connect(result["paths"])
+            try:
+                primary_project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                second_project_id = create_project(
+                    connection,
+                    result["paths"],
+                    actor_id="agent_allocator",
+                    name="Second Project",
+                    description="secondary",
+                    project_type="custom",
+                    mode="greenfield",
+                )["project"]["project_id"]
+
+                supervisor_result = run_supervisor_once(connection, allocate_limit=4, project_paths=result["paths"])
+                primary_assigned = connection.execute(
+                    "SELECT COUNT(*) AS count FROM tasks WHERE project_id = ? AND status = 'assigned'",
+                    (primary_project_id,),
+                ).fetchone()["count"]
+                second_assigned = connection.execute(
+                    "SELECT COUNT(*) AS count FROM tasks WHERE project_id = ? AND status = 'assigned'",
+                    (second_project_id,),
+                ).fetchone()["count"]
+            finally:
+                connection.close()
+
+            project_ids = [item["project_id"] for item in supervisor_result["project_runs"]]
+            self.assertEqual(project_ids, [primary_project_id, second_project_id])
+            self.assertEqual(supervisor_result["assigned_count"], 4)
+            self.assertGreater(primary_assigned, 0)
+            self.assertGreater(second_assigned, 0)
 
     def test_stale_session_does_not_clobber_agent_with_other_active_session(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -830,7 +830,8 @@ export async function updateEscalationStatus(escalationId: string, action: "appr
 
 export async function runSupervisorPass(allocateLimit?: number) {
   const payload = await postJson<SupervisorRunResponse>("/api/supervisor/run", {
-    allocate_limit: allocateLimit ?? null
+    allocate_limit: allocateLimit ?? null,
+    project_id: getSelectedProjectId()
   });
   return payload as SupervisorRunResponse;
 }

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -38,8 +38,10 @@ export function OverviewPage() {
     try {
       const result = await runSupervisorPass(2);
       setSupervisorResult(result);
+      const projectScopeSummary =
+        result.project_runs.length > 1 ? ` across ${result.project_runs.length} projects` : "";
       setNotice(
-        `Supervisor refreshed ${result.ready_changes.length} tasks, assigned ${result.assigned_count}, and found ${result.stale_sessions.length} stale sessions.`
+        `Supervisor refreshed ${result.ready_changes.length} tasks, assigned ${result.assigned_count}, and found ${result.stale_sessions.length} stale sessions${projectScopeSummary}.`
       );
       setOverview(await fetchOverview());
     } catch {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -834,6 +834,29 @@ export interface SupervisorAllocation {
   already_assigned?: boolean;
 }
 
+export interface SupervisorProjectRun {
+  project_id: string;
+  ready_changes: SupervisorReadyChange[];
+  allocations: SupervisorAllocation[];
+  assigned_count: number;
+  auto_recovered_tasks: Array<{
+    task_id: string;
+    status: string;
+    review_state?: string | null;
+    next_retry_at?: string | null;
+    next_retry_reason?: string | null;
+  }>;
+  stale_sessions: Array<{
+    session_id: string;
+    task_id: string;
+    repeated_failure_alert?: {
+      alert_id: string;
+      task_id: string;
+      failure_count: number;
+    } | null;
+  }>;
+}
+
 export interface SupervisorRunResponse {
   ready_changes: SupervisorReadyChange[];
   allocations: SupervisorAllocation[];
@@ -854,4 +877,5 @@ export interface SupervisorRunResponse {
       failure_count: number;
     } | null;
   }>;
+  project_runs: SupervisorProjectRun[];
 }


### PR DESCRIPTION
## Done on main
- [x] Multi-project read scoping and project lifecycle exist
- [x] Supervisor, recovery, provider, and control-room reads already resolve active projects correctly
- [ ] Background orchestration is still not fully project-aware on main: scheduler allocation and supervisor passes can still operate globally

## Working in this PR
- [x] Scope scheduler ready resolution, ready refresh, and idle-agent allocation by project
- [x] Prevent cross-project task assignment when an idle agent asks for the next task
- [x] Let supervisor runs target a selected project or iterate all active projects with a per-project result breakdown
- [x] Expose scoped supervisor runs through API, CLI, and the Overview page request path
- [x] Add regressions for cross-project allocation leakage and scoped/all-project supervisor behavior

## Still to do after this PR
- [ ] Project-aware background worker loops beyond the manual supervisor pass
- [ ] Deeper multi-project write-path coverage across remaining operator actions
- [ ] Per-project runtime isolation and sandbox execution

## Validation
- `python3 -m py_compile src/maas/services/scheduler.py src/maas/supervisor.py src/maas/api.py src/maas/cli.py tests/test_scheduler_api.py tests/test_supervisor_api.py`
- `PYTHONPATH=src python3 -m unittest tests.test_scheduler_api`
- `PYTHONPATH=src python3 -m unittest tests.test_supervisor_api`
- `PYTHONPATH=src python3 -m unittest tests.test_board`
- `PYTHONPATH=src python3 -m unittest tests.test_projects_api`
- `git diff --check`

## Notes
- I did not run a frontend build because local `tsc` is still not installed in this checkout.
