### PR TITLE
Implement roadmap #226, #228, and #229

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Relevant design and roadmap documents:
 - [Codex MVP Control-Loop Hardening Plan](docs/implementation/17-codex-mvp-control-loop-hardening-plan.md)
 - [Codex MVP Doctor, Planning, and Delivery Loop Plan](docs/implementation/18-codex-mvp-doctor-delivery-loop-plan.md)
 - [Codex MVP Delivery Execution and Verification Plan](docs/implementation/19-codex-mvp-delivery-execution-verification-plan.md)
+- [Codex MVP Explainability, Review, and Memory Plan](docs/implementation/20-codex-mvp-explainability-review-memory-plan.md)
 
 There is also a standalone product mockup for the current direction in [mockups/maas-codex-mvp/README.md](mockups/maas-codex-mvp/README.md).
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -41,6 +41,8 @@ For the current doctor, planning, and delivery-loop batch, see [18-codex-mvp-doc
 
 For the current delivery execution and verification batch, see [19-codex-mvp-delivery-execution-verification-plan.md](19-codex-mvp-delivery-execution-verification-plan.md).
 
+For the current explainability, review, and memory batch, see [20-codex-mvp-explainability-review-memory-plan.md](20-codex-mvp-explainability-review-memory-plan.md).
+
 Legend for numbered roadmap checklists:
 
 - `[x]` completed in the current numbered delivery sequence
@@ -126,10 +128,10 @@ The next product-defining sequence starts after the historical `#81-#151` chain 
 - [x] `#223` Memory feedback, decay, and usefulness scoring
 - [x] `#224` Async supervision v3 and overdue decision posture
 - [x] `#225` GitHub delivery execution and PR sync
-- [ ] `#226` Goal-to-issue explainability and critical path view
+- [x] `#226` Goal-to-issue explainability and critical path view
 - [ ] `#227` No-progress diagnosis with one-click remediation
-- [ ] `#228` Review packets v4 and bulk decision UX
-- [ ] `#229` Memory usefulness by item, not just by run
+- [x] `#228` Review packets v4 and bulk decision UX
+- [x] `#229` Memory usefulness by item, not just by run
 - [x] `#230` Delivery verification gates
 - [ ] `#231` Live run observability v2
 - [ ] `#232` Autopilot governance v2

--- a/docs/implementation/20-codex-mvp-explainability-review-memory-plan.md
+++ b/docs/implementation/20-codex-mvp-explainability-review-memory-plan.md
@@ -1,0 +1,52 @@
+# MAAS Codex MVP Explainability, Review, and Memory Plan
+
+Status: implemented on `codex/goal-explainability-review-memory-usefulness`
+
+## Goal
+
+Take MAAS from "goal synthesis, grouped review, and usefulness-scored memory exist" to "the operator can see why a synthesized issue exists, what is currently on the critical path, review related low-risk issues as a real packet, and judge memory usefulness item by item."
+
+This branch implements the second post-`#224` batch:
+
+- `#226` Goal-to-issue explainability and critical path view
+- `#228` Review packets v4 and bulk decision UX
+- `#229` Memory usefulness by item, not just by run
+
+## Sequence
+
+- [x] `#226` Goal-to-issue explainability and critical path view
+  - expose a goal-plan explainability read model over synthesized issues
+  - show why each synthesized issue exists, what it depends on, and what it unlocks
+  - surface the current critical path and current focus in both goal planning and issue detail
+
+- [x] `#228` Review packets v4 and bulk decision UX
+  - extend grouped review packets with packet scope and per-issue membership
+  - let the operator inspect packet contents before applying a bulk decision
+  - support packet-scoped partial selection so one PR batch does not force all-or-nothing review clicks
+
+- [x] `#229` Memory usefulness by item, not just by run
+  - explain why a memory item matched the current issue or retrieval query
+  - expose item-level usefulness summaries from reuse, success, and failure history
+  - feed that item usefulness back into prompt construction and issue detail instead of leaving it implicit in run history
+
+## What Landed
+
+- goal planning now returns synthesized-step explainability plus a current critical-path view
+- issue detail now shows why a goal-linked issue exists, what it depends on, and whether it sits on the current critical path
+- review packets now include their actual member issues and packet scope so bulk review is inspectable before action
+- the `Issues` surface now supports packet-scoped selection instead of only blind approve-all / reject-all actions
+- memory retrieval now exposes match reasons and usefulness summaries per artifact, and prompt assembly includes that item-level signal
+
+## Why This Order
+
+The delivery and verification batch made shipping truthful, but the operator still had to infer too much in three places:
+
+- why a synthesized issue existed
+- what a grouped review packet actually contained
+- whether a retrieved memory item was useful because of one successful run or because it had repeatedly helped
+
+This batch closes those gaps in the same operator loop:
+
+- planning gets explainability
+- review gets inspectable bulk decisions
+- memory gets item-level usefulness instead of opaque scoring

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -61,6 +61,7 @@ See:
 - [17-codex-mvp-control-loop-hardening-plan.md](17-codex-mvp-control-loop-hardening-plan.md)
 - [18-codex-mvp-doctor-delivery-loop-plan.md](18-codex-mvp-doctor-delivery-loop-plan.md)
 - [19-codex-mvp-delivery-execution-verification-plan.md](19-codex-mvp-delivery-execution-verification-plan.md)
+- [20-codex-mvp-explainability-review-memory-plan.md](20-codex-mvp-explainability-review-memory-plan.md)
 - [mockups/maas-codex-mvp/README.md](../../mockups/maas-codex-mvp/README.md)
 
 ## GitHub Project Contract
@@ -236,6 +237,9 @@ The current product-modeling sequence on `codex/linear-vibekanban-cockpit` now c
 - [x] `#223` is implemented on `codex/codex-mvp-doctor-delivery-loop`
 - [x] `#224` is implemented on `codex/codex-mvp-doctor-delivery-loop`
 - [x] `#225` is shipped on `main`
+- [x] `#226` is implemented on `codex/goal-explainability-review-memory-usefulness`
+- [x] `#228` is implemented on `codex/goal-explainability-review-memory-usefulness`
+- [x] `#229` is implemented on `codex/goal-explainability-review-memory-usefulness`
 - [x] `#230` is shipped on `main`
 
 ## Historical Numbered Roadmap

--- a/src/maas/services/board.py
+++ b/src/maas/services/board.py
@@ -213,10 +213,14 @@ def _group_review_packets(review_items):
                 "title": packet.get("title"),
                 "summary": packet.get("summary"),
                 "recommended_decision": packet.get("recommended_decision"),
+                "packet_scope": packet.get("packet_scope"),
+                "packet_scope_id": packet.get("packet_scope_id"),
+                "packet_scope_label": packet.get("packet_scope_label"),
                 "eligible_count": 0,
                 "eligible_task_ids": [],
                 "eligible_issue_keys": [],
                 "auto_approve_eligible_count": 0,
+                "items": [],
             },
         )
         bucket["eligible_count"] += 1
@@ -225,6 +229,26 @@ def _group_review_packets(review_items):
             bucket["eligible_issue_keys"].append(task["issue_key"])
         if eligibility.get("auto_approve_eligible"):
             bucket["auto_approve_eligible_count"] += 1
+        bucket["items"].append(
+            {
+                "task_id": task["task_id"],
+                "issue_key": task.get("issue_key"),
+                "title": task["title"],
+                "status": task["status"],
+                "priority": task["priority"],
+                "goal_id": (task.get("goal") or {}).get("id"),
+                "goal_title": (task.get("goal") or {}).get("title"),
+                "agent_id": (task.get("agent") or {}).get("id"),
+                "agent_name": (task.get("agent") or {}).get("name"),
+                "review_state": task.get("review_state"),
+                "latest_verification_status": task.get("latest_verification_status"),
+                "latest_verification_at": task.get("latest_verification_at"),
+                "latest_verification_command": task.get("latest_verification_command"),
+                "review_age_hours": task.get("review_age_hours"),
+                "decision_mode": eligibility.get("decision_mode"),
+                "auto_approve_eligible": bool(eligibility.get("auto_approve_eligible")),
+            }
+        )
     return list(packets.values())
 
 

--- a/src/maas/services/codex_mvp.py
+++ b/src/maas/services/codex_mvp.py
@@ -7,6 +7,7 @@ import os
 from maas.services.artifacts import fetch_artifacts
 from maas.services.delivery import fetch_task_delivery_status
 from maas.services.git_workspaces import fetch_task_git_workspace
+from maas.services.goal_planning import fetch_goal_explainability
 from maas.services.memory import fetch_project_memory, retrieve_relevant_memory
 from maas.services.provider_jobs import fetch_provider_jobs
 from maas.services.review_policy import evaluate_review_decision_state, fetch_project_review_policy
@@ -1501,6 +1502,18 @@ def fetch_issue_detail(connection, project_paths, project_id, task_id):
         goal_title=task_row["goal_title"],
         limit=4,
     )
+    goal_explainability = None
+    if task_row["goal_id"]:
+        goal_plan = fetch_goal_explainability(connection, project_id, task_row["goal_id"])
+        selected_plan_task = next(
+            (item for item in goal_plan.get("tasks") or [] if item["task_id"] == task_id),
+            None,
+        )
+        if selected_plan_task is not None:
+            goal_explainability = {
+                **goal_plan,
+                "task": selected_plan_task,
+            }
     delivery = fetch_task_delivery_status(connection, project_paths, task_id, project_id=project_id)
     latest_run = runs[0] if runs else None
     recovery_playbook = _issue_recovery_playbook(
@@ -1545,6 +1558,7 @@ def fetch_issue_detail(connection, project_paths, project_id, task_id):
         "verification_runs": verification_runs,
         "review_decision": review_decision,
         "recovery_playbook": recovery_playbook,
+        "goal_explainability": goal_explainability,
         "memory_context": related_memory,
         "delivery": delivery,
         "git_workspace": git_workspace,

--- a/src/maas/services/goal_planning.py
+++ b/src/maas/services/goal_planning.py
@@ -24,6 +24,39 @@ def _load_project_config(project_row):
     return payload if isinstance(payload, dict) else {}
 
 
+def _issue_key_lookup(connection, project_id):
+    rows = connection.execute(
+        """
+        SELECT task_id
+        FROM tasks
+        WHERE project_id = ?
+        ORDER BY created_at ASC, task_id ASC
+        """,
+        (project_id,),
+    ).fetchall()
+    return {
+        row["task_id"]: "ISS-{0}".format(str(index + 1).zfill(4))
+        for index, row in enumerate(rows)
+    }
+
+
+def _acceptance_summary(acceptance_items):
+    labels = []
+    for item in acceptance_items or []:
+        item_type = item.get("type")
+        if item_type == "artifact_exists":
+            labels.append("produce operator-visible output")
+        elif item_type == "human_review":
+            labels.append("clear human review")
+        elif item_type:
+            labels.append(item_type.replace("_", " "))
+    if not labels:
+        return "No explicit acceptance criteria are recorded."
+    if len(labels) == 1:
+        return labels[0].capitalize() + "."
+    return "{0}, and {1}.".format(", ".join(label for label in labels[:-1]), labels[-1]).capitalize()
+
+
 def _goal_issue_specs(goal_row, project_row):
     title = (goal_row["title"] or "").strip()
     description = (goal_row["description"] or "").strip()
@@ -41,6 +74,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Clarify the scope, success criteria, and evidence expected for this research goal.\n\nGoal context:\n{0}".format(description or title),
                 "priority": high,
                 "acceptance": [{"type": "artifact_exists"}],
+                "stage_label": "Research framing",
+                "why_it_exists": "Create a clear research brief so later evidence can be judged against the same scope and success criteria.",
             },
             {
                 "slug": "collect-baseline-context",
@@ -48,6 +83,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Inspect the current repository, prior memory, and relevant artifacts before deep work begins.",
                 "priority": max(high - 4, 1),
                 "acceptance": [{"type": "artifact_exists"}],
+                "stage_label": "Context grounding",
+                "why_it_exists": "Ground the investigation in the current repo, prior memory, and existing artifacts before deeper work starts.",
             },
             {
                 "slug": "run-core-investigation",
@@ -55,6 +92,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Execute the primary research loop and record evidence-backed findings.",
                 "priority": max(high - 8, 1),
                 "acceptance": [{"type": "artifact_exists"}],
+                "stage_label": "Investigation",
+                "why_it_exists": "Produce the main research output that moves the goal forward with evidence rather than assumptions.",
             },
             {
                 "slug": "verify-findings",
@@ -62,6 +101,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Validate the research outputs and capture what still looks uncertain or risky.",
                 "priority": max(high - 12, 1),
                 "acceptance": [{"type": "artifact_exists"}, {"type": "human_review"}],
+                "stage_label": "Verification",
+                "why_it_exists": "Turn raw findings into trustworthy evidence by testing them and surfacing remaining risk explicitly.",
             },
             {
                 "slug": "prepare-delivery-report",
@@ -69,6 +110,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Package the research result into a deliverable summary, artifact bundle, or draft PR narrative.",
                 "priority": max(high - 16, 1),
                 "acceptance": [{"type": "artifact_exists"}, {"type": "human_review"}],
+                "stage_label": "Delivery",
+                "why_it_exists": "Package the result so an operator or downstream reviewer can consume it without replaying the whole investigation.",
             },
         ]
     else:
@@ -79,6 +122,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Turn the goal into operator-visible scope, acceptance criteria, and expected outputs.\n\nGoal context:\n{0}".format(description or title),
                 "priority": high,
                 "acceptance": [{"type": "artifact_exists"}],
+                "stage_label": "Planning",
+                "why_it_exists": "Make the goal explicit enough that implementation, review, and delivery all share the same definition of done.",
             },
             {
                 "slug": "inspect-current-surface",
@@ -86,6 +131,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Inspect the repo, existing memory, and current state before implementation starts.",
                 "priority": max(high - 4, 1),
                 "acceptance": [{"type": "artifact_exists"}],
+                "stage_label": "Grounding",
+                "why_it_exists": "Anchor the goal in the current implementation surface and reusable memory before changing code or behavior.",
             },
             {
                 "slug": "implement-primary-slice",
@@ -93,6 +140,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Complete the highest-value change required to advance this goal and record the output.",
                 "priority": max(high - 8, 1),
                 "acceptance": [{"type": "artifact_exists"}],
+                "stage_label": "Implementation",
+                "why_it_exists": "Deliver the main code or artifact change that materially advances the goal instead of just preparing for it.",
             },
             {
                 "slug": "verify-output-and-risk",
@@ -100,6 +149,8 @@ def _goal_issue_specs(goal_row, project_row):
                 "description": "Run verification, collect evidence, and summarize remaining risks or follow-up items.",
                 "priority": max(high - 12, 1),
                 "acceptance": [{"type": "artifact_exists"}, {"type": "human_review"}],
+                "stage_label": "Verification",
+                "why_it_exists": "Convert the implementation result into reviewable evidence and expose the remaining risk posture before delivery.",
             },
             {
                 "slug": "prepare-delivery-package",
@@ -111,9 +162,295 @@ def _goal_issue_specs(goal_row, project_row):
                 ),
                 "priority": max(high - 16, 1),
                 "acceptance": [{"type": "artifact_exists"}, {"type": "human_review"}],
+                "stage_label": "Delivery",
+                "why_it_exists": "Package the finished slice into a handoff that can be reviewed, approved, or synchronized to GitHub cleanly.",
             },
         ]
     return specs
+
+
+def _goal_plan_task_rows(connection, project_id, goal_id, origin):
+    return connection.execute(
+        """
+        SELECT
+            task_id,
+            title,
+            status,
+            priority,
+            review_state,
+            synthesis_key,
+            created_at,
+            updated_at
+        FROM tasks
+        WHERE project_id = ?
+          AND goal_id = ?
+          AND synthesis_origin = ?
+        ORDER BY created_at ASC, task_id ASC
+        """,
+        (project_id, goal_id, origin),
+    ).fetchall()
+
+
+def _goal_plan_dependency_rows(connection, project_id, task_ids):
+    if not task_ids:
+        return []
+    placeholders = ", ".join("?" for _ in task_ids)
+    params = [project_id, *task_ids, *task_ids]
+    return connection.execute(
+        """
+        SELECT source_task_id, target_task_id
+        FROM task_dependencies
+        WHERE project_id = ?
+          AND dependency_type = 'blocks'
+          AND source_task_id IN ({placeholders})
+          AND target_task_id IN ({placeholders})
+        ORDER BY rowid ASC
+        """.format(placeholders=placeholders),
+        tuple(params),
+    ).fetchall()
+
+
+def _goal_step_slug(origin, synthesis_key):
+    prefix = "{0}:".format(origin)
+    if synthesis_key and synthesis_key.startswith(prefix):
+        return synthesis_key[len(prefix) :]
+    return None
+
+
+def _build_goal_plan_explainability(connection, project_id, goal_row, project_row, issue_keys=None):
+    origin = "goal_plan:{0}".format(goal_row["goal_id"])
+    task_rows = _goal_plan_task_rows(connection, project_id, goal_row["goal_id"], origin)
+    issue_keys = issue_keys or _issue_key_lookup(connection, project_id)
+    if not task_rows:
+        return {
+            "goal_id": goal_row["goal_id"],
+            "goal_title": goal_row["title"],
+            "origin": origin,
+            "summary": {
+                "task_count": 0,
+                "done_count": 0,
+                "open_count": 0,
+                "blocked_count": 0,
+                "review_count": 0,
+                "current_focus_task_id": None,
+                "current_focus_issue_key": None,
+                "current_focus_title": None,
+                "current_focus_status": None,
+                "critical_path_remaining": 0,
+            },
+            "critical_path": {
+                "remaining_task_count": 0,
+                "items": [],
+            },
+            "tasks": [],
+        }
+
+    specs = _goal_issue_specs(goal_row, project_row)
+    specs_by_slug = {
+        spec["slug"]: spec
+        for spec in specs
+    }
+    spec_order = {
+        spec["slug"]: index
+        for index, spec in enumerate(specs)
+    }
+    task_rows = sorted(
+        task_rows,
+        key=lambda row: (
+            spec_order.get(_goal_step_slug(origin, row["synthesis_key"]), len(spec_order)),
+            row["created_at"] or "",
+            row["task_id"],
+        ),
+    )
+    ordered_ids = [row["task_id"] for row in task_rows]
+    row_by_id = {row["task_id"]: dict(row) for row in task_rows}
+    dependency_rows = _goal_plan_dependency_rows(connection, project_id, ordered_ids)
+    depends_on = {task_id: [] for task_id in ordered_ids}
+    unlocks = {task_id: [] for task_id in ordered_ids}
+    for row in dependency_rows:
+        source_task_id = row["source_task_id"]
+        target_task_id = row["target_task_id"]
+        unlocks.setdefault(source_task_id, []).append(target_task_id)
+        depends_on.setdefault(target_task_id, []).append(source_task_id)
+
+    remaining_ids = [
+        task_id
+        for task_id in ordered_ids
+        if row_by_id[task_id]["status"] not in {"done", "cancelled"}
+    ]
+    remaining_set = set(remaining_ids)
+    longest_to_end = {}
+    next_on_path = {}
+    position_by_id = {task_id: index for index, task_id in enumerate(ordered_ids)}
+    for task_id in reversed(ordered_ids):
+        if task_id not in remaining_set:
+            continue
+        child_ids = [child_id for child_id in unlocks.get(task_id, []) if child_id in remaining_set]
+        if not child_ids:
+            longest_to_end[task_id] = 1
+            next_on_path[task_id] = None
+            continue
+        best_child_id = max(
+            child_ids,
+            key=lambda child_id: (
+                longest_to_end.get(child_id, 1),
+                -position_by_id.get(child_id, 0),
+            ),
+        )
+        longest_to_end[task_id] = 1 + longest_to_end.get(best_child_id, 1)
+        next_on_path[task_id] = best_child_id
+
+    root_ids = [
+        task_id
+        for task_id in remaining_ids
+        if not [dependency_id for dependency_id in depends_on.get(task_id, []) if dependency_id in remaining_set]
+    ]
+    critical_path_ids = []
+    if root_ids:
+        start_id = max(
+            root_ids,
+            key=lambda task_id: (
+                longest_to_end.get(task_id, 1),
+                -position_by_id.get(task_id, 0),
+            ),
+        )
+        focus_id = start_id
+        while focus_id:
+            critical_path_ids.append(focus_id)
+            focus_id = next_on_path.get(focus_id)
+    critical_rank = {
+        task_id: index + 1
+        for index, task_id in enumerate(critical_path_ids)
+    }
+
+    current_focus_id = next(
+        (task_id for task_id in ordered_ids if row_by_id[task_id]["status"] not in {"done", "cancelled"}),
+        None,
+    )
+
+    tasks = []
+    for index, row in enumerate(task_rows, start=1):
+        task_row = row_by_id[row["task_id"]]
+        slug = _goal_step_slug(origin, task_row.get("synthesis_key"))
+        spec = specs_by_slug.get(slug) or {}
+        open_dependency_count = len(
+            [
+                task_id
+                for task_id in depends_on.get(row["task_id"], [])
+                if row_by_id.get(task_id, {}).get("status") not in {"done", "cancelled"}
+            ]
+        )
+        open_unlock_count = len(
+            [
+                task_id
+                for task_id in unlocks.get(row["task_id"], [])
+                if row_by_id.get(task_id, {}).get("status") not in {"done", "cancelled"}
+            ]
+        )
+        depends_on_items = [
+            {
+                "task_id": dependency_id,
+                "issue_key": issue_keys.get(dependency_id),
+                "title": row_by_id.get(dependency_id, {}).get("title"),
+                "status": row_by_id.get(dependency_id, {}).get("status"),
+            }
+            for dependency_id in depends_on.get(row["task_id"], [])
+        ]
+        unlock_items = [
+            {
+                "task_id": dependency_id,
+                "issue_key": issue_keys.get(dependency_id),
+                "title": row_by_id.get(dependency_id, {}).get("title"),
+                "status": row_by_id.get(dependency_id, {}).get("status"),
+            }
+            for dependency_id in unlocks.get(row["task_id"], [])
+        ]
+        tasks.append(
+            {
+                "task_id": row["task_id"],
+                "issue_key": issue_keys.get(row["task_id"]),
+                "title": row["title"],
+                "status": row["status"],
+                "review_state": row["review_state"],
+                "priority": row["priority"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+                "step_index": index,
+                "step_count": len(task_rows),
+                "step_slug": slug,
+                "stage_label": spec.get("stage_label"),
+                "why_it_exists": spec.get("why_it_exists") or "This synthesized issue exists to move the goal forward in sequence.",
+                "acceptance_summary": _acceptance_summary(spec.get("acceptance") or []),
+                "depends_on": depends_on_items,
+                "unlocks": unlock_items,
+                "depends_on_count": len(depends_on_items),
+                "unlocks_count": len(unlock_items),
+                "open_dependency_count": open_dependency_count,
+                "open_unlock_count": open_unlock_count,
+                "is_current_focus": row["task_id"] == current_focus_id,
+                "is_on_critical_path": row["task_id"] in critical_rank,
+                "critical_path_rank": critical_rank.get(row["task_id"]),
+            }
+        )
+
+    done_count = len([item for item in tasks if item["status"] == "done"])
+    blocked_count = len([item for item in tasks if item["status"] == "blocked"])
+    review_count = len([item for item in tasks if item["status"] == "review"])
+    open_count = len([item for item in tasks if item["status"] not in {"done", "cancelled"}])
+    current_focus = next((item for item in tasks if item["task_id"] == current_focus_id), None)
+    critical_path_items = [
+        next(item for item in tasks if item["task_id"] == task_id)
+        for task_id in critical_path_ids
+    ]
+
+    return {
+        "goal_id": goal_row["goal_id"],
+        "goal_title": goal_row["title"],
+        "origin": origin,
+        "summary": {
+            "task_count": len(tasks),
+            "done_count": done_count,
+            "open_count": open_count,
+            "blocked_count": blocked_count,
+            "review_count": review_count,
+            "current_focus_task_id": current_focus["task_id"] if current_focus else None,
+            "current_focus_issue_key": current_focus["issue_key"] if current_focus else None,
+            "current_focus_title": current_focus["title"] if current_focus else None,
+            "current_focus_status": current_focus["status"] if current_focus else None,
+            "critical_path_remaining": len(critical_path_items),
+        },
+        "critical_path": {
+            "remaining_task_count": len(critical_path_items),
+            "items": critical_path_items,
+        },
+        "tasks": tasks,
+    }
+
+
+def fetch_goal_explainability(connection, project_id, goal_id):
+    resolved_project_id = resolve_project_id(connection, project_id, include_archived=False)
+    if resolved_project_id is None:
+        raise ValueError("project not found")
+    goal_row = connection.execute(
+        """
+        SELECT goal_id, project_id, title, description, status, goal_type, priority
+        FROM goals
+        WHERE project_id = ?
+          AND goal_id = ?
+        """,
+        (resolved_project_id, goal_id),
+    ).fetchone()
+    if goal_row is None:
+        raise ValueError("goal not found")
+    project_row = resolve_project(connection, resolved_project_id, include_archived=False)
+    issue_keys = _issue_key_lookup(connection, resolved_project_id)
+    return _build_goal_plan_explainability(
+        connection,
+        resolved_project_id,
+        goal_row,
+        project_row,
+        issue_keys=issue_keys,
+    )
 
 
 def create_goal(connection, actor_id, project_id, title, description="", goal_type="initiative", priority=75, parent_goal_id=None):
@@ -416,6 +753,8 @@ def fetch_goal_planning(connection, project_id=None, goal_id=None):
     resolved_project_id = resolve_project_id(connection, project_id, include_archived=False)
     if resolved_project_id is None:
         raise ValueError("project not found")
+    project_row = resolve_project(connection, resolved_project_id, include_archived=False)
+    issue_keys = _issue_key_lookup(connection, resolved_project_id)
     params = [resolved_project_id]
     where_clause = "WHERE goals.project_id = ?"
     if goal_id:
@@ -456,6 +795,17 @@ def fetch_goal_planning(connection, project_id=None, goal_id=None):
             row[key] or 0
             for key in ("planned_tasks", "ready_tasks", "assigned_tasks", "active_tasks", "review_tasks", "blocked_tasks")
         )
+        plan = (
+            _build_goal_plan_explainability(
+                connection,
+                resolved_project_id,
+                row,
+                project_row,
+                issue_keys=issue_keys,
+            )
+            if synthesized_tasks
+            else None
+        )
         goals.append(
             {
                 "goal_id": row["goal_id"],
@@ -484,6 +834,7 @@ def fetch_goal_planning(connection, project_id=None, goal_id=None):
                     else "Refresh or inspect the synthesized issue plan."
                 ),
                 "open_issue_count": total_open,
+                "plan": plan,
             }
         )
     return {

--- a/src/maas/services/memory.py
+++ b/src/maas/services/memory.py
@@ -119,6 +119,24 @@ def _memory_usage_fields(memory_payload):
     }
 
 
+def _memory_usefulness_summary(entry):
+    used_count = int(entry.get("used_count") or 0)
+    success_count = int(entry.get("success_count") or 0)
+    failure_count = int(entry.get("failure_count") or 0)
+    last_outcome = entry.get("last_run_outcome")
+    usefulness = entry.get("usefulness") or "unknown"
+    if used_count <= 0:
+        return "Not reused yet."
+    parts = ["Used {0}x".format(used_count)]
+    if success_count or failure_count:
+        parts.append("{0} successful, {1} failed".format(success_count, failure_count))
+    if last_outcome:
+        parts.append("last outcome {0}".format(str(last_outcome).replace("_", " ")))
+    if usefulness != "unknown":
+        parts.append("usefulness {0}".format(usefulness))
+    return "; ".join(parts) + "."
+
+
 def _memory_recency_sort_key(value):
     if not value:
         return 0
@@ -129,6 +147,59 @@ def _memory_recency_sort_key(value):
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc).timestamp()
+
+
+def _memory_match_details(query_tokens, entry):
+    ordered_tokens = []
+    seen = set()
+    for token in query_tokens:
+        if token in seen:
+            continue
+        ordered_tokens.append(token)
+        seen.add(token)
+    fields = {
+        "title": _tokenize(entry.get("title") or ""),
+        "summary": _tokenize(entry.get("summary") or ""),
+        "tags": _tokenize(" ".join(entry.get("tags") or [])),
+        "preview": _tokenize((entry.get("preview") or {}).get("content") or ""),
+    }
+    matches_by_field = {}
+    for field_name, tokens in fields.items():
+        token_set = set(tokens)
+        matches = [token for token in ordered_tokens if token in token_set]
+        if matches:
+            matches_by_field[field_name] = matches
+    matched_terms = []
+    matched_seen = set()
+    for field_name in ("title", "summary", "tags", "preview"):
+        for token in matches_by_field.get(field_name, []):
+            if token in matched_seen:
+                continue
+            matched_terms.append(token)
+            matched_seen.add(token)
+    reasons = []
+    labels = {
+        "title": "title",
+        "summary": "summary",
+        "tags": "tags",
+        "preview": "preview",
+    }
+    for field_name in ("title", "summary", "tags", "preview"):
+        matches = matches_by_field.get(field_name) or []
+        if not matches:
+            continue
+        reasons.append("{0}: {1}".format(labels[field_name], ", ".join(matches[:3])))
+    if not reasons:
+        return {
+            "matched_terms": [],
+            "match_reasons": [],
+            "match_summary": "Retrieved from project memory.",
+        }
+    return {
+        "matched_terms": matched_terms,
+        "match_reasons": reasons,
+        "match_summary": "Matched " + "; ".join(reasons[:3]) + ".",
+    }
 
 
 def _memory_summary_from_preview(preview):
@@ -347,14 +418,19 @@ def fetch_project_memory(connection, project_id, limit=40, search=None):
             **_memory_freshness_fields(memory.get("promoted_at")),
             **_memory_usage_fields(memory),
         }
+        entry["usefulness_summary"] = _memory_usefulness_summary(entry)
         if query_tokens:
             candidate = " ".join([entry["title"], entry["summary"], " ".join(entry["tags"] or [])])
             score = _score_tokens(query_tokens, candidate)
             if score <= 0:
                 continue
             entry["score"] = score
+            entry.update(_memory_match_details(query_tokens, entry))
         else:
             entry["score"] = 0
+            entry["matched_terms"] = []
+            entry["match_reasons"] = []
+            entry["match_summary"] = "Retrieved from project memory."
         entries.append(entry)
     if query_tokens:
         entries = sorted(
@@ -387,12 +463,13 @@ def retrieve_relevant_memory(connection, project_id, task_title, task_descriptio
     candidates = fetch_project_memory(connection, project_id, limit=200)
     scored = []
     for candidate in candidates:
+        preview = candidate.get("preview") or {}
         candidate_text = " ".join(
             [
                 candidate.get("title") or "",
                 candidate.get("summary") or "",
                 " ".join(candidate.get("tags") or []),
-                candidate.get("preview", {}).get("content") or "",
+                preview.get("content") or "",
             ]
         )
         score = _score_tokens(query_tokens, candidate_text)
@@ -400,6 +477,7 @@ def retrieve_relevant_memory(connection, project_id, task_title, task_descriptio
             continue
         candidate_copy = dict(candidate)
         candidate_copy["score"] = score
+        candidate_copy.update(_memory_match_details(query_tokens, candidate_copy))
         scored.append(candidate_copy)
     scored.sort(
         key=lambda item: (
@@ -454,6 +532,11 @@ def build_task_prompt(connection, task_id):
                 title=entry.get("title") or entry["artifact_id"],
                 summary=snippet or entry.get("summary") or "No summary available.",
             )
+            usefulness_summary = entry.get("usefulness_summary")
+            match_summary = entry.get("match_summary")
+            if usefulness_summary or match_summary:
+                details = " ".join(part for part in (match_summary, usefulness_summary) if part)
+                block += " ({0})".format(details)
             if current_length + len(block) > MEMORY_CONTEXT_MAX_CHARS:
                 break
             memory_lines.append(block)
@@ -475,12 +558,16 @@ def build_task_prompt(connection, task_id):
                 "age_days": entry.get("age_days"),
                 "freshness": entry.get("freshness"),
                 "stale": entry.get("stale"),
+                "matched_terms": entry.get("matched_terms") or [],
+                "match_reasons": entry.get("match_reasons") or [],
+                "match_summary": entry.get("match_summary"),
                 "used_count": entry.get("used_count"),
                 "success_count": entry.get("success_count"),
                 "failure_count": entry.get("failure_count"),
                 "success_ratio": entry.get("success_ratio"),
                 "usefulness_score": entry.get("usefulness_score"),
                 "usefulness": entry.get("usefulness"),
+                "usefulness_summary": entry.get("usefulness_summary"),
             }
             for entry in memory_entries
         ],

--- a/tests/test_codex_mvp_api.py
+++ b/tests/test_codex_mvp_api.py
@@ -12,7 +12,8 @@ from maas.ids import generate_id
 from maas.services.bootstrap import bootstrap_project
 from maas.services.delivery import _git_repo_snapshot, fetch_delivery_overview, fetch_task_delivery_status
 from maas.services.environment_doctor import _git_status, fetch_environment_doctor
-from maas.services.goal_planning import create_goal, synthesize_goal_issues, _goal_issue_specs
+from maas.services.codex_mvp import fetch_issue_detail
+from maas.services.goal_planning import create_goal, fetch_goal_planning, synthesize_goal_issues, _goal_issue_specs
 from maas.services.memory import retrieve_relevant_memory
 
 class CodexMvpApiTest(unittest.TestCase):
@@ -499,6 +500,117 @@ class CodexMvpApiTest(unittest.TestCase):
             finally:
                 connection.close()
 
+    def test_goal_planning_exposes_explainability_and_critical_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Goal Explainability Test", description="goal explainability", project_type="custom")
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                goal = create_goal(
+                    connection,
+                    "agent_allocator",
+                    None,
+                    "Ship explainable issue planning",
+                    "Show why each synthesized issue exists and what it unlocks.",
+                    priority=84,
+                )
+                synthesize_payload = synthesize_goal_issues(connection, None, goal["goal_id"], "agent_allocator", refresh=True)
+                first_task_id = synthesize_payload["task_ids"][0]
+                second_task_id = synthesize_payload["task_ids"][1]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'done', review_state = 'approved'
+                    WHERE task_id = ?
+                    """,
+                    (first_task_id,),
+                )
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'review', review_state = 'review_requested'
+                    WHERE task_id = ?
+                    """,
+                    (second_task_id,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            planning_response = client.get("/api/goals/planning")
+            self.assertEqual(planning_response.status_code, 200)
+            planning_payload = planning_response.json()
+            planning_goal = next(item for item in planning_payload["items"] if item["goal_id"] == goal["goal_id"])
+            self.assertIsNotNone(planning_goal["plan"])
+            self.assertEqual(planning_goal["plan"]["summary"]["current_focus_task_id"], second_task_id)
+            self.assertGreaterEqual(planning_goal["plan"]["critical_path"]["remaining_task_count"], 1)
+            self.assertIn("why each synthesized issue exists".split()[0], planning_goal["description"].lower())
+            self.assertTrue(planning_goal["plan"]["tasks"][0]["why_it_exists"])
+            self.assertTrue(planning_goal["plan"]["tasks"][0]["acceptance_summary"])
+
+            detail_response = client.get(f"/api/issues/{second_task_id}")
+            self.assertEqual(detail_response.status_code, 200)
+            detail_payload = detail_response.json()
+            self.assertIsNotNone(detail_payload["goal_explainability"])
+            self.assertEqual(detail_payload["goal_explainability"]["task"]["task_id"], second_task_id)
+            self.assertTrue(detail_payload["goal_explainability"]["task"]["is_current_focus"])
+            self.assertGreaterEqual(len(detail_payload["goal_explainability"]["critical_path"]["items"]), 1)
+
+    def test_goal_planning_current_focus_respects_synthesized_step_order(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Goal Explainability Ordering Test", description="goal explainability ordering", project_type="custom")
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                project_id = connection.execute(
+                    """
+                    SELECT project_id
+                    FROM projects
+                    LIMIT 1
+                    """
+                ).fetchone()["project_id"]
+                goal = create_goal(
+                    connection,
+                    "agent_allocator",
+                    None,
+                    "Ship explainable issue planning",
+                    "Show why each synthesized issue exists and what it unlocks.",
+                    priority=84,
+                )
+                synthesize_payload = synthesize_goal_issues(connection, None, goal["goal_id"], "agent_allocator", refresh=True)
+                first_task_id = synthesize_payload["task_ids"][0]
+                second_task_id = synthesize_payload["task_ids"][1]
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'done', review_state = 'approved'
+                    WHERE task_id = ?
+                    """,
+                    (first_task_id,),
+                )
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'review', review_state = 'review_requested'
+                    WHERE task_id = ?
+                    """,
+                    (second_task_id,),
+                )
+                connection.commit()
+
+                planning_payload = fetch_goal_planning(connection, project_id=project_id)
+                planning_goal = next(item for item in planning_payload["items"] if item["goal_id"] == goal["goal_id"])
+                detail_payload = fetch_issue_detail(connection, paths, project_id, second_task_id)
+            finally:
+                connection.close()
+
+            self.assertEqual(planning_goal["plan"]["summary"]["current_focus_task_id"], second_task_id)
+            self.assertEqual(planning_goal["plan"]["tasks"][0]["task_id"], first_task_id)
+            self.assertEqual(planning_goal["plan"]["tasks"][1]["task_id"], second_task_id)
+            self.assertEqual(detail_payload["goal_explainability"]["task"]["task_id"], second_task_id)
+            self.assertTrue(detail_payload["goal_explainability"]["task"]["is_current_focus"])
+
     def test_memory_promotion_feeds_memory_index_retrieval_and_issue_detail(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bootstrap_project(tmpdir, name="Codex Memory Test", description="codex memory", project_type="custom")
@@ -570,6 +682,203 @@ class CodexMvpApiTest(unittest.TestCase):
             self.assertGreaterEqual(len(detail_payload["memory_context"]), 1)
             self.assertEqual(detail_payload["memory_context"][0]["artifact_id"], artifact_id)
             self.assertEqual(detail_payload["memory_context"][0]["freshness"], "fresh")
+
+    def test_review_packets_expose_items_for_bulk_decision(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Codex Review Packet V4 Test", description="codex packet ux", project_type="custom")
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                tasks = connection.execute(
+                    """
+                    SELECT task_id, project_id
+                    FROM tasks
+                    ORDER BY created_at ASC
+                    LIMIT 2
+                    """
+                ).fetchall()
+                for task in tasks:
+                    connection.execute(
+                        """
+                        UPDATE tasks
+                        SET status = 'review', priority = 50, review_state = 'review_requested'
+                        WHERE task_id = ?
+                        """,
+                        (task["task_id"],),
+                    )
+                    connection.execute(
+                        """
+                        INSERT INTO verification_runs (
+                            verification_run_id, project_id, task_id, command, status, exit_code, output_excerpt,
+                            artifact_id, actor_id, started_at, finished_at
+                        ) VALUES (
+                            ?, ?, ?, 'pytest tests/test_packet_v4.py', 'passed', 0, '1 passed',
+                            NULL, 'agent_reviewer', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                        )
+                        """,
+                        (generate_id("vrf"), task["project_id"], task["task_id"]),
+                    )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            response = client.get("/api/issues/index")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            packet = payload["queue"]["review"]["batch_review"]["packets"][0]
+            self.assertEqual(packet["eligible_count"], 2)
+            self.assertEqual(len(packet["items"]), 2)
+            self.assertTrue(packet["packet_scope_label"])
+            self.assertEqual(packet["items"][0]["decision_mode"], "auto_approve")
+            self.assertTrue(packet["items"][0]["issue_key"])
+
+    def test_memory_item_usefulness_and_match_reason_are_exposed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Codex Memory Usefulness Test", description="codex memory usefulness", project_type="custom")
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                task = connection.execute(
+                    """
+                    SELECT task_id, project_id
+                    FROM tasks
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET title = 'Prepare explainability packet', description = 'Reuse the explainability packet and memory summary.'
+                    WHERE task_id = ?
+                    """,
+                    (task["task_id"],),
+                )
+                artifact_path = os.path.join(paths.artifacts_dir, "explainability-packet.txt")
+                with open(artifact_path, "w", encoding="utf-8") as handle:
+                    handle.write("explainability packet\ncritical path narrative\n")
+                artifact_id = generate_id("art")
+                connection.execute(
+                    """
+                    INSERT INTO artifacts (
+                        artifact_id, project_id, task_id, session_id, artifact_type, path, metadata_json
+                    ) VALUES (?, ?, ?, NULL, 'note', ?, ?)
+                    """,
+                    (
+                        artifact_id,
+                        task["project_id"],
+                        task["task_id"],
+                        artifact_path,
+                        json.dumps(
+                            {
+                                "memory": {
+                                    "promoted": True,
+                                    "title": "Explainability packet",
+                                    "summary": "Reusable explainability summary",
+                                    "tags": ["explainability", "packet"],
+                                    "promoted_at": "2026-03-26T10:00:00+00:00",
+                                    "promoted_by": "agent_allocator",
+                                    "used_count": 3,
+                                    "success_count": 2,
+                                    "failure_count": 1,
+                                    "last_used_at": "2026-03-26T11:00:00+00:00",
+                                    "last_run_outcome": "completed",
+                                }
+                            }
+                        ),
+                    ),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            client = TestClient(create_app(tmpdir))
+            detail_response = client.get(f"/api/issues/{task['task_id']}")
+            self.assertEqual(detail_response.status_code, 200)
+            detail_payload = detail_response.json()
+            self.assertEqual(detail_payload["memory_context"][0]["artifact_id"], artifact_id)
+            self.assertIn("Matched", detail_payload["memory_context"][0]["match_summary"])
+            self.assertIn("Used 3x", detail_payload["memory_context"][0]["usefulness_summary"])
+
+            retrieval_response = client.get("/api/retrieval/search", params={"search": "explainability packet"})
+            self.assertEqual(retrieval_response.status_code, 200)
+            retrieval_payload = retrieval_response.json()
+            self.assertEqual(retrieval_payload["memory"][0]["artifact_id"], artifact_id)
+            self.assertGreaterEqual(len(retrieval_payload["memory"][0]["matched_terms"]), 1)
+
+    def test_memory_retrieval_handles_promoted_items_without_preview(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Codex Memory Preview Gap Test", description="codex memory preview gap", project_type="custom")
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                task = connection.execute(
+                    """
+                    SELECT task_id, project_id
+                    FROM tasks
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                connection.execute(
+                    """
+                    UPDATE tasks
+                    SET title = 'Prepare explainability packet', description = 'Reuse the explainability packet and memory summary.'
+                    WHERE task_id = ?
+                    """,
+                    (task["task_id"],),
+                )
+                artifact_id = generate_id("art")
+                connection.execute(
+                    """
+                    INSERT INTO artifacts (
+                        artifact_id, project_id, task_id, session_id, artifact_type, path, metadata_json
+                    ) VALUES (?, ?, ?, NULL, 'note', ?, ?)
+                    """,
+                    (
+                        artifact_id,
+                        task["project_id"],
+                        task["task_id"],
+                        os.path.join(paths.artifacts_dir, "missing-explainability-packet.txt"),
+                        json.dumps(
+                            {
+                                "memory": {
+                                    "promoted": True,
+                                    "title": "Explainability packet",
+                                    "summary": "Reusable explainability summary",
+                                    "tags": ["explainability", "packet"],
+                                    "promoted_at": "2026-03-26T10:00:00+00:00",
+                                    "promoted_by": "agent_allocator",
+                                    "used_count": 3,
+                                    "success_count": 2,
+                                    "failure_count": 1,
+                                    "last_used_at": "2026-03-26T11:00:00+00:00",
+                                    "last_run_outcome": "completed",
+                                }
+                            }
+                        ),
+                    ),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            reopened = connect(paths)
+            try:
+                retrieved = retrieve_relevant_memory(
+                    reopened,
+                    task["project_id"],
+                    "Prepare explainability packet",
+                    task_description="Reuse the explainability packet and memory summary.",
+                )
+            finally:
+                reopened.close()
+
+            self.assertEqual(retrieved[0]["artifact_id"], artifact_id)
+            self.assertIsNone(retrieved[0]["preview"])
+            self.assertIn("Matched", retrieved[0]["match_summary"])
+            self.assertIn("Used 3x", retrieved[0]["usefulness_summary"])
 
     def test_memory_retrieval_prefers_newer_promoted_items_on_score_ties(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/src/components/CodexIssueDetailPanel.tsx
+++ b/web/src/components/CodexIssueDetailPanel.tsx
@@ -233,6 +233,8 @@ export function CodexIssueDetailPanel({
   const isSimulationRun = executionMode === "local_simulation";
   const reviewDecision = detail?.review_decision ?? null;
   const reviewPacket = reviewDecision?.grouped_review_packet ?? null;
+  const goalExplainability = detail?.goal_explainability ?? null;
+  const explainedTask = goalExplainability?.task ?? null;
   const issueActions = actions ? <div className="codex-detail-actions">{actions}</div> : null;
   const checks = detail?.verification_runs ?? [];
   const selectedRunRecord = selectedRunDetail;
@@ -247,6 +249,47 @@ export function CodexIssueDetailPanel({
   }, [detail?.memory_context, promotedMemoryItems]);
   const reviewBundle = (
     <>
+      {goalExplainability && explainedTask ? (
+        <section className="codex-detail-section">
+          <div className="codex-section-heading">
+            <strong>Goal explainability</strong>
+            <span>
+              Step {explainedTask.step_index}/{explainedTask.step_count}
+            </span>
+          </div>
+          <div className="codex-run-list codex-run-list--compact">
+            <div className="codex-output-item">
+              <strong>
+                {explainedTask.stage_label ?? "Planned step"}
+                {explainedTask.is_current_focus ? " · current focus" : ""}
+                {explainedTask.is_on_critical_path ? ` · critical path #${explainedTask.critical_path_rank}` : ""}
+              </strong>
+              <span>{explainedTask.why_it_exists}</span>
+              <span>{explainedTask.acceptance_summary}</span>
+              <span>
+                {explainedTask.open_dependency_count > 0
+                  ? `${explainedTask.open_dependency_count} open dependency`
+                  : "No open dependencies"}
+                {explainedTask.open_unlock_count > 0 ? ` · unlocks ${explainedTask.open_unlock_count}` : ""}
+              </span>
+            </div>
+            {goalExplainability.critical_path.items.length ? (
+              <div className="codex-output-item">
+                <strong>Current critical path</strong>
+                <span>
+                  {goalExplainability.critical_path.remaining_task_count} remaining step
+                  {goalExplainability.critical_path.remaining_task_count === 1 ? "" : "s"}
+                </span>
+                <span>
+                  {goalExplainability.critical_path.items
+                    .map((item) => item.issue_key ?? item.title)
+                    .join(" -> ")}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
       <section className="codex-detail-section">
         <div className="codex-section-heading">
           <strong>Latest output</strong>
@@ -344,6 +387,7 @@ export function CodexIssueDetailPanel({
               <div key={`${item.artifact_id}:${item.task_id ?? "memory"}`} className="codex-output-item">
                 <strong>{item.title ?? item.path ?? item.artifact_id}</strong>
                 <span>{item.summary ?? "No memory summary recorded."}</span>
+                {item.match_summary ? <span>{item.match_summary}</span> : null}
                 <span>
                   {(item.tags?.length ?? 0) ? item.tags?.join(", ") : "No tags"}
                   {item.score != null ? ` · score ${item.score}` : ""}
@@ -352,6 +396,7 @@ export function CodexIssueDetailPanel({
                   {item.usefulness ? ` · usefulness ${item.usefulness}` : ""}
                   {item.used_count != null ? ` · used ${item.used_count}x` : ""}
                 </span>
+                {item.usefulness_summary ? <span>{item.usefulness_summary}</span> : null}
               </div>
             ))}
           </div>

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -1265,6 +1265,7 @@ export function fetchCodexIssueDetail(taskId: string, signal?: AbortSignal, onFa
         actions: [],
         confidence: "low",
       },
+      goal_explainability: null,
       memory_context: [],
       git_workspace: null,
     },

--- a/web/src/pages/CodexIssuesPage.tsx
+++ b/web/src/pages/CodexIssuesPage.tsx
@@ -45,6 +45,7 @@ export function CodexIssuesPage({
   const [detail, setDetail] = useState<CodexIssueDetailResponse | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [packetSelection, setPacketSelection] = useState<Record<string, string[]>>({});
   const livePulse = useLivePulse();
   const { scope, savedScopes, setScope, applySavedScope, saveCurrentScope, deleteSavedScope, resetScope } =
     useCodexIssueScope(getSelectedProjectId(), "issues");
@@ -117,9 +118,11 @@ export function CodexIssuesPage({
     const visibleTaskIds = new Set(filteredReviewItems.map((task) => task.task_id));
     return (issueIndex?.queue.review.batch_review?.packets ?? [])
       .map((packet) => {
-        const eligibleTaskIds = (packet.eligible_task_ids ?? []).filter((taskId) => visibleTaskIds.has(taskId));
+        const packetItems = (packet.items ?? []).filter((item) => visibleTaskIds.has(item.task_id));
+        const eligibleTaskIds = packetItems.map((item) => item.task_id);
         return {
           ...packet,
+          items: packetItems,
           eligible_task_ids: eligibleTaskIds,
           eligible_count: eligibleTaskIds.length,
         };
@@ -147,6 +150,41 @@ export function CodexIssuesPage({
     setSelectedTaskId(visibleItems[0]?.task_id ?? null);
   }, [selectedTaskId, filteredOpenTasks, filteredResolved, visibleItems]);
 
+  useEffect(() => {
+    setPacketSelection((current) => {
+      const next = { ...current };
+      const activePacketKeys = new Set(filteredBatchReviewPackets.map((packet) => packet.packet_key));
+      for (const packet of filteredBatchReviewPackets) {
+        const validIds = new Set((packet.eligible_task_ids ?? []).filter(Boolean));
+        if (packet.packet_key in current) {
+          next[packet.packet_key] = (current[packet.packet_key] ?? []).filter((taskId) => validIds.has(taskId));
+          continue;
+        }
+        next[packet.packet_key] = [...validIds];
+      }
+      for (const key of Object.keys(next)) {
+        if (!activePacketKeys.has(key)) {
+          delete next[key];
+        }
+      }
+      return next;
+    });
+  }, [filteredBatchReviewPackets]);
+
+  function selectedPacketTaskIds(packetKey: string, eligibleTaskIds: string[]) {
+    return (packetSelection[packetKey] ?? eligibleTaskIds).filter((taskId) => eligibleTaskIds.includes(taskId));
+  }
+
+  function togglePacketTask(packetKey: string, taskId: string) {
+    setPacketSelection((current) => {
+      const existing = current[packetKey] ?? [];
+      const next = existing.includes(taskId)
+        ? existing.filter((candidate) => candidate !== taskId)
+        : [...existing, taskId];
+      return { ...current, [packetKey]: next };
+    });
+  }
+
   async function runAction(key: string, action: () => Promise<unknown>, message: string) {
     setPendingKey(key);
     setNotice(null);
@@ -165,11 +203,16 @@ export function CodexIssuesPage({
     }
   }
 
-  async function handleBatchReview(packetTaskIds: string[], decision: "approve" | "reject", packetTitle?: string | null) {
+  async function handleBatchReview(
+    packetKey: string,
+    packetTaskIds: string[],
+    decision: "approve" | "reject",
+    packetTitle?: string | null
+  ) {
     if (!packetTaskIds.length) {
       return;
     }
-    setPendingKey(`batch-review:${decision}:${packetTaskIds[0]}`);
+    setPendingKey(`batch-review:${decision}:${packetKey}`);
     setNotice(null);
     try {
       await batchReviewIssues(packetTaskIds, decision);
@@ -367,36 +410,102 @@ export function CodexIssuesPage({
                           {(packet.eligible_count ?? packet.eligible_task_ids?.length ?? 0)} issue
                           {(packet.eligible_count ?? packet.eligible_task_ids?.length ?? 0) === 1 ? "" : "s"}
                         </span>
+                        <span>
+                          {packet.packet_scope_label ?? "Shared scope"}
+                          {packet.auto_approve_eligible_count ? ` · ${packet.auto_approve_eligible_count} auto-approve eligible` : ""}
+                        </span>
+                        <div className="codex-run-list codex-run-list--compact">
+                          {(packet.items ?? []).map((item) => {
+                            const selectedIds = selectedPacketTaskIds(packet.packet_key, packet.eligible_task_ids ?? []);
+                            const checked = selectedIds.includes(item.task_id);
+                            return (
+                              <div key={item.task_id} className="codex-packet-item">
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => togglePacketTask(packet.packet_key, item.task_id)}
+                                />
+                                <button
+                                  type="button"
+                                  className="codex-packet-item__content"
+                                  onClick={() => setSelectedTaskId(item.task_id)}
+                                >
+                                  <strong>{item.issue_key ?? item.task_id} · {item.title}</strong>
+                                  <span>
+                                    {item.goal_title ?? "Unlinked goal"}
+                                    {item.latest_verification_at ? ` · ${formatTimestamp(item.latest_verification_at)}` : ""}
+                                  </span>
+                                  <span>
+                                    {priorityLabel(item.priority)}
+                                    {item.auto_approve_eligible ? " · auto-approve eligible" : ""}
+                                  </span>
+                                </button>
+                              </div>
+                            );
+                          })}
+                        </div>
                         <div className="codex-detail-actions">
                           <button
                             type="button"
+                            className="codex-button"
+                            onClick={() =>
+                              setPacketSelection((current) => ({
+                                ...current,
+                                [packet.packet_key]: [...(packet.eligible_task_ids ?? [])],
+                              }))
+                            }
+                          >
+                            Select all
+                          </button>
+                          <button
+                            type="button"
+                            className="codex-button"
+                            onClick={() =>
+                              setPacketSelection((current) => ({
+                                ...current,
+                                [packet.packet_key]: [],
+                              }))
+                            }
+                          >
+                            Clear
+                          </button>
+                          <button
+                            type="button"
                             className="codex-button codex-button--primary"
-                            disabled={pendingKey === `batch-review:approve:${packet.eligible_task_ids?.[0] ?? packet.packet_key}`}
+                            disabled={
+                              pendingKey === `batch-review:approve:${packet.packet_key}` ||
+                              selectedPacketTaskIds(packet.packet_key, packet.eligible_task_ids ?? []).length === 0
+                            }
                             onClick={() =>
                               void handleBatchReview(
-                                packet.eligible_task_ids ?? [],
+                                packet.packet_key,
+                                selectedPacketTaskIds(packet.packet_key, packet.eligible_task_ids ?? []),
                                 "approve",
                                 packet.title ?? "the low-risk review packet"
                               )
                             }
                           >
-                            {pendingKey === `batch-review:approve:${packet.eligible_task_ids?.[0] ?? packet.packet_key}`
+                            {pendingKey === `batch-review:approve:${packet.packet_key}`
                               ? "Approving..."
-                              : `Approve ${packet.eligible_count ?? packet.eligible_task_ids?.length ?? 0}`}
+                              : `Approve ${selectedPacketTaskIds(packet.packet_key, packet.eligible_task_ids ?? []).length}`}
                           </button>
                           <button
                             type="button"
                             className="codex-button"
-                            disabled={pendingKey === `batch-review:reject:${packet.eligible_task_ids?.[0] ?? packet.packet_key}`}
+                            disabled={
+                              pendingKey === `batch-review:reject:${packet.packet_key}` ||
+                              selectedPacketTaskIds(packet.packet_key, packet.eligible_task_ids ?? []).length === 0
+                            }
                             onClick={() =>
                               void handleBatchReview(
-                                packet.eligible_task_ids ?? [],
+                                packet.packet_key,
+                                selectedPacketTaskIds(packet.packet_key, packet.eligible_task_ids ?? []),
                                 "reject",
                                 packet.title ?? "the low-risk review packet"
                               )
                             }
                           >
-                            {pendingKey === `batch-review:reject:${packet.eligible_task_ids?.[0] ?? packet.packet_key}`
+                            {pendingKey === `batch-review:reject:${packet.packet_key}`
                               ? "Updating..."
                               : "Request changes"}
                           </button>

--- a/web/src/pages/CommandPage.tsx
+++ b/web/src/pages/CommandPage.tsx
@@ -579,6 +579,40 @@ export function CommandPage({
                 </div>
                 <span>{goal.goal_type} · {goal.open_issue_count} open issues · {goal.synthesized_tasks} synthesized</span>
                 <p>{goal.description || "No goal description recorded yet."}</p>
+                {goal.plan?.summary.task_count ? (
+                  <div className="codex-list-block">
+                    <strong>
+                      Critical path: {goal.plan.summary.critical_path_remaining} remaining
+                      {goal.plan.summary.current_focus_issue_key || goal.plan.summary.current_focus_title
+                        ? ` · focus ${goal.plan.summary.current_focus_issue_key ?? goal.plan.summary.current_focus_title}`
+                        : ""}
+                    </strong>
+                    <div className="codex-run-list codex-run-list--compact">
+                      {goal.plan.tasks.slice(0, 5).map((item) => (
+                        <button
+                          key={item.task_id}
+                          type="button"
+                          className="codex-output-item codex-output-item--interactive"
+                          onClick={() => {
+                            setPendingTaskFocus(item.task_id);
+                            onNavigate("issues");
+                          }}
+                        >
+                          <strong>
+                            {item.issue_key ?? item.task_id} · {item.title}
+                          </strong>
+                          <span>
+                            Step {item.step_index}/{item.step_count}
+                            {item.stage_label ? ` · ${item.stage_label}` : ""}
+                            {item.is_current_focus ? " · current focus" : ""}
+                            {item.is_on_critical_path ? ` · critical path #${item.critical_path_rank}` : ""}
+                          </span>
+                          <span>{item.why_it_exists}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
                 <div className="codex-detail-actions">
                   <button
                     type="button"
@@ -852,7 +886,12 @@ export function CommandPage({
                       <span>{item.promoted_at ? formatTimestamp(item.promoted_at) : "memory"}</span>
                     </div>
                     <span>{item.summary || item.path || "Promoted project memory"}</span>
-                    <p>{item.preview?.content || item.tags?.join(" · ") || "Reusable context for future Codex runs."}</p>
+                    <p>{item.match_summary || item.preview?.content || item.tags?.join(" · ") || "Reusable context for future Codex runs."}</p>
+                    <p>
+                      {(item.tags?.length ?? 0) ? item.tags?.join(" · ") : "No tags"}
+                      {item.usefulness ? ` · usefulness ${item.usefulness}` : ""}
+                      {item.usefulness_summary ? ` · ${item.usefulness_summary}` : ""}
+                    </p>
                   </button>
                 ))}
                 {!retrieval?.memory.length ? <div className="codex-empty-copy">No memory matches.</div> : null}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5008,6 +5008,14 @@ body {
   padding: 12px 14px;
 }
 
+.codex-output-item--interactive {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 90%, transparent 10%);
+  text-align: left;
+}
+
 .codex-run-item,
 .codex-history-item {
   border: 1px solid var(--line);
@@ -5019,6 +5027,26 @@ body {
   display: grid;
   gap: 10px;
   padding: 14px;
+}
+
+.codex-run-list--compact {
+  padding: 0;
+}
+
+.codex-packet-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.codex-packet-item__content {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+  text-align: left;
 }
 
 .codex-output-selector {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -396,6 +396,81 @@ export interface GoalPlanningItem {
   synthesized_tasks: number;
   supports_synthesis: boolean;
   next_step: string;
+  plan?: {
+    goal_id: string;
+    goal_title?: string | null;
+    origin: string;
+    summary: {
+      task_count: number;
+      done_count: number;
+      open_count: number;
+      blocked_count: number;
+      review_count: number;
+      current_focus_task_id?: string | null;
+      current_focus_issue_key?: string | null;
+      current_focus_title?: string | null;
+      current_focus_status?: string | null;
+      critical_path_remaining: number;
+    };
+    critical_path: {
+      remaining_task_count: number;
+      items: Array<{
+        task_id: string;
+        issue_key?: string | null;
+        title: string;
+        status: string;
+        review_state?: string | null;
+        priority: number;
+        step_index: number;
+        step_count: number;
+        stage_label?: string | null;
+        why_it_exists: string;
+        acceptance_summary: string;
+        depends_on_count: number;
+        unlocks_count: number;
+        open_dependency_count: number;
+        open_unlock_count: number;
+        is_current_focus: boolean;
+        is_on_critical_path: boolean;
+        critical_path_rank?: number | null;
+      }>;
+    };
+    tasks: Array<{
+      task_id: string;
+      issue_key?: string | null;
+      title: string;
+      status: string;
+      review_state?: string | null;
+      priority: number;
+      created_at?: string | null;
+      updated_at?: string | null;
+      step_index: number;
+      step_count: number;
+      step_slug?: string | null;
+      stage_label?: string | null;
+      why_it_exists: string;
+      acceptance_summary: string;
+      depends_on: Array<{
+        task_id: string;
+        issue_key?: string | null;
+        title?: string | null;
+        status?: string | null;
+      }>;
+      unlocks: Array<{
+        task_id: string;
+        issue_key?: string | null;
+        title?: string | null;
+        status?: string | null;
+      }>;
+      depends_on_count: number;
+      unlocks_count: number;
+      open_dependency_count: number;
+      open_unlock_count: number;
+      is_current_focus: boolean;
+      is_on_critical_path: boolean;
+      critical_path_rank?: number | null;
+    }>;
+  } | null;
 }
 
 export interface GoalPlanningResponse {
@@ -1994,6 +2069,9 @@ export interface CodexIssueDetailResponse {
     actions: string[];
     confidence: string;
   };
+  goal_explainability?: NonNullable<GoalPlanningItem["plan"]> & {
+    task: NonNullable<GoalPlanningItem["plan"]>["tasks"][number];
+  } | null;
   memory_context?: Array<{
     artifact_id: string;
     task_id?: string | null;
@@ -2009,12 +2087,16 @@ export interface CodexIssueDetailResponse {
     age_days?: number | null;
     freshness?: "fresh" | "aging" | "stale" | "unknown";
     stale?: boolean;
+    matched_terms?: string[];
+    match_reasons?: string[];
+    match_summary?: string | null;
     used_count?: number;
     success_count?: number;
     failure_count?: number;
     success_ratio?: number | null;
     usefulness_score?: number;
     usefulness?: "high" | "medium" | "low" | "unknown";
+    usefulness_summary?: string | null;
     preview?: {
       content?: string;
       truncated?: boolean;
@@ -2054,6 +2136,27 @@ export interface CodexIssueQueueBucket {
       eligible_task_ids?: string[];
       eligible_issue_keys?: string[];
       auto_approve_eligible_count?: number;
+      packet_scope?: string | null;
+      packet_scope_id?: string | null;
+      packet_scope_label?: string | null;
+      items?: Array<{
+        task_id: string;
+        issue_key?: string | null;
+        title: string;
+        status: string;
+        priority: number;
+        goal_id?: string | null;
+        goal_title?: string | null;
+        agent_id?: string | null;
+        agent_name?: string | null;
+        review_state?: string | null;
+        latest_verification_status?: string | null;
+        latest_verification_at?: string | null;
+        latest_verification_command?: string | null;
+        review_age_hours?: number | null;
+        decision_mode?: string | null;
+        auto_approve_eligible?: boolean;
+      }>;
     }>;
     summary: string;
   };
@@ -2169,6 +2272,19 @@ export interface CodexRetrievalSearchResponse {
     tags?: string[];
     promoted_at?: string | null;
     promoted_by?: string | null;
+    age_days?: number | null;
+    freshness?: "fresh" | "aging" | "stale" | "unknown";
+    stale?: boolean;
+    matched_terms?: string[];
+    match_reasons?: string[];
+    match_summary?: string | null;
+    used_count?: number;
+    success_count?: number;
+    failure_count?: number;
+    success_ratio?: number | null;
+    usefulness_score?: number;
+    usefulness?: "high" | "medium" | "low" | "unknown";
+    usefulness_summary?: string | null;
     preview?: {
       content?: string;
       truncated?: boolean;


### PR DESCRIPTION
## Summary
- add goal-to-issue explainability with critical-path and current-focus data in goal planning and issue detail
- add inspectable review packets with per-issue selection for bulk review decisions in Issues
- add item-level memory match and usefulness summaries, and feed them into retrieval and prompt construction

## Validation
- npm run build
- PYTHONPATH=src .venv/bin/python -m compileall src/maas
- PYTHONPATH=src .venv/bin/python -m pytest tests/test_codex_mvp_api.py -q -k "goal_planning_current_focus_respects_synthesized_step_order or memory_retrieval_handles_promoted_items_without_preview"
- direct service checks for goal explainability, issue detail explainability, review packet membership, and memory usefulness prompt context

## Notes
- the FastAPI TestClient path is hanging in this shell wrapper for unchanged endpoints too, so API-path validation in this environment was replaced with direct service validation and direct regression tests
- I requested subagent review, but this runtime does not expose a working delegation tool, so the review pass here was manual and validation-backed

Closes #97
Closes #99
Closes #100
