### PR TITLE
Implement Theater execution field and agent motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Relevant design and roadmap documents:
 - [Codex MVP Brownfield Execution Leverage](docs/implementation/23-codex-mvp-brownfield-execution-leverage.md)
 - [Codex MVP Brownfield Drift, Refresh, and Trust](docs/implementation/24-codex-mvp-brownfield-drift-refresh-trust.md)
 - [Execution Theater Foundation](docs/implementation/26-execution-theater-foundation.md)
+- [Execution Theater Field and Agent Motion](docs/implementation/27-execution-theater-field-agent-motion.md)
 
 There is also a standalone product mockup for the current direction in [mockups/maas-codex-mvp/README.md](mockups/maas-codex-mvp/README.md).
 

--- a/docs/implementation/27-execution-theater-field-agent-motion.md
+++ b/docs/implementation/27-execution-theater-field-agent-motion.md
@@ -1,0 +1,73 @@
+# Execution Theater Field and Agent Motion
+
+## Goal
+
+Strengthen the Theater execution field so it shows real agent ownership and runtime posture directly in the field instead of only in the side focus panel.
+
+This batch keeps the Theater surface navigation-first, but it makes the field itself feel live:
+
+- issue cards keep stable slots for ownership
+- agent tokens move only when their task ownership or runtime target changes
+- idle and attention agents stay visible in a reserve dock instead of disappearing from the field
+
+## Scope
+
+This batch adds:
+
+- measured agent anchors inside issue cards and in a reserve dock
+- a token overlay that animates agents between those anchors as live data refreshes
+- stronger issue, run, agent, and task-linked branch focus synchronization when selecting a token or run
+- clearer in-field posture for stale runs and review or attention states
+
+It does not yet add:
+
+- richer branch-tree behavior beyond the current lineage foundation
+- degraded-state and performance hardening for larger topologies
+- a separate Theater-specific mutation model
+
+## UI Shape
+
+The top panel is now composed of three parts:
+
+1. `Agent motion dock`
+   Unattached or non-field agents remain visible in grouped reserve sections:
+   - `Needs attention`
+   - `Working off field`
+   - `Waiting on review`
+   - `Idle reserve`
+
+2. `Execution lanes`
+   Issue cards keep stable ordering and reserve explicit anchor slots for currently attached agents.
+
+3. `Token overlay`
+   Agent tokens are rendered once and repositioned to the correct anchor as data changes, which gives motion without reflowing the cards themselves.
+
+The movement is intentionally constrained. Tokens should not drift or animate on every refresh; they should only move when the underlying assignment or visible target changes.
+
+## Operator Effect
+
+The result is a better answer to:
+
+- which agent is actually attached to this issue right now?
+- which agents are idle versus waiting versus in trouble?
+- which run is stale enough to deserve attention before opening a deeper page?
+
+The Theater page remains a coordination surface, not a second issue editor.
+
+## Validation
+
+This batch is validated by:
+
+- frontend production build
+- diff cleanliness checks
+- focused manual validation of selection routing and token motion across live refreshes
+
+Frontend test infrastructure is still intentionally light in this repo, so build plus direct review remains the primary local signal for this batch.
+
+## Follow-on Batches
+
+The next Theater slices should build on this field behavior:
+
+- richer branch, worktree, and PR lineage interaction
+- degraded rendering and partial-data fallbacks
+- performance caps, instrumentation, and broader internal-production hardening

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -68,6 +68,7 @@ See:
 - [23-codex-mvp-brownfield-execution-leverage.md](23-codex-mvp-brownfield-execution-leverage.md)
 - [24-codex-mvp-brownfield-drift-refresh-trust.md](24-codex-mvp-brownfield-drift-refresh-trust.md)
 - [26-execution-theater-foundation.md](26-execution-theater-foundation.md)
+- [27-execution-theater-field-agent-motion.md](27-execution-theater-field-agent-motion.md)
 - [mockups/maas-codex-mvp/README.md](../../mockups/maas-codex-mvp/README.md)
 
 ## GitHub Project Contract

--- a/web/src/pages/TheaterPage.tsx
+++ b/web/src/pages/TheaterPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { fetchTheater } from "../lib/controlRoomApi";
 import { formatTimestamp, priorityLabel, statusLabel } from "../lib/codexMvp";
 import { consumePendingAgentFocus, setPendingAgentFocus } from "../lib/agentFocus";
@@ -9,6 +9,15 @@ import { useLivePulse } from "../lib/useLivePulse";
 import type { TheaterAgent, TheaterBranch, TheaterIssue, TheaterResponse, TheaterRun } from "../types";
 
 type ViewTarget = "command" | "theater" | "work" | "issues" | "agents" | "runs" | "system" | "projects" | "settings";
+type TheaterDockState = "attention" | "working" | "review_wait" | "idle";
+
+const THEATER_DOCK_ORDER: TheaterDockState[] = ["attention", "working", "review_wait", "idle"];
+const THEATER_DOCK_LABELS: Record<TheaterDockState, string> = {
+  attention: "Needs attention",
+  working: "Working off field",
+  review_wait: "Waiting on review",
+  idle: "Idle reserve",
+};
 
 function heartbeatLabel(seconds?: number | null) {
   if (seconds == null) {
@@ -56,6 +65,39 @@ function agentTone(agent: TheaterAgent) {
   return "default";
 }
 
+function dockStateForAgent(agent: TheaterAgent): TheaterDockState {
+  if (agent.visual_state === "attention" || agent.visual_state === "blocked") {
+    return "attention";
+  }
+  if (agent.visual_state === "working") {
+    return "working";
+  }
+  if (agent.visual_state === "review_wait") {
+    return "review_wait";
+  }
+  return "idle";
+}
+
+function agentStatusLabel(agent: TheaterAgent, run?: TheaterRun | null) {
+  if (run?.is_stale) {
+    return "stale run";
+  }
+  if (run?.is_live) {
+    return run.status.replaceAll("_", " ");
+  }
+  return agent.visual_state.replaceAll("_", " ");
+}
+
+function issueRunLabel(issue: TheaterIssue) {
+  if (issue.current_run_stale) {
+    return "Stale run";
+  }
+  if (issue.current_run_status) {
+    return issue.current_run_status.replaceAll("_", " ");
+  }
+  return "No run";
+}
+
 export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => void }) {
   const [payload, setPayload] = useState<TheaterResponse | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -64,7 +106,12 @@ export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => 
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(() => consumePendingAgentFocus());
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [selectedBranchId, setSelectedBranchId] = useState<string | null>(null);
+  const [fieldLayoutVersion, setFieldLayoutVersion] = useState(0);
+  const [agentPositions, setAgentPositions] = useState<Record<string, { left: number; top: number }>>({});
   const livePulse = useLivePulse();
+  const fieldRef = useRef<HTMLDivElement | null>(null);
+  const lanesRef = useRef<HTMLDivElement | null>(null);
+  const anchorRefs = useRef(new Map<string, HTMLDivElement>());
 
   useEffect(() => subscribeProjectScope(setSelectedProjectId), []);
 
@@ -111,6 +158,7 @@ export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => 
     () => new Map((payload?.pull_requests ?? []).map((pr) => [pr.pr_id, pr])),
     [payload?.pull_requests]
   );
+  const runsById = useMemo(() => new Map((payload?.runs ?? []).map((run) => [run.run_id, run])), [payload?.runs]);
   const issueToBranch = useMemo(() => {
     const mapping = new Map<string, string>();
     for (const link of payload?.links.issue_to_branch ?? []) {
@@ -118,6 +166,7 @@ export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => 
     }
     return mapping;
   }, [payload?.links.issue_to_branch]);
+  const issueIds = useMemo(() => new Set((payload?.issues ?? []).map((issue) => issue.task_id)), [payload?.issues]);
   const selectedIssue = payload?.issues.find((issue) => issue.task_id === selectedIssueId) ?? null;
   const selectedBranch =
     (selectedBranchId ? branchesById.get(selectedBranchId) : null) ??
@@ -156,6 +205,138 @@ export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => 
     return grouped;
   }, [payload?.issues, payload?.layout.issue_lanes]);
 
+  const fieldAgents = useMemo(() => {
+    const attached = new Map<string, TheaterAgent[]>();
+    const docked: Record<TheaterDockState, TheaterAgent[]> = {
+      attention: [],
+      working: [],
+      review_wait: [],
+      idle: [],
+    };
+
+    for (const agent of payload?.agents ?? []) {
+      if (agent.current_task_id && issueIds.has(agent.current_task_id)) {
+        attached.set(agent.current_task_id, [...(attached.get(agent.current_task_id) ?? []), agent]);
+        continue;
+      }
+      docked[dockStateForAgent(agent)].push(agent);
+    }
+
+    for (const [taskId, agents] of attached.entries()) {
+      agents.sort((left, right) => left.name.localeCompare(right.name));
+      attached.set(taskId, agents);
+    }
+    for (const key of THEATER_DOCK_ORDER) {
+      docked[key].sort((left, right) => left.name.localeCompare(right.name));
+    }
+
+    return { attached, docked };
+  }, [payload?.agents, issueIds]);
+
+  const anchorKeyForAgent = useMemo(
+    () => (agent: TheaterAgent) => {
+      if (agent.current_task_id && issueIds.has(agent.current_task_id)) {
+        return `issue:${agent.current_task_id}:${agent.agent_id}`;
+      }
+      return `dock:${dockStateForAgent(agent)}:${agent.agent_id}`;
+    },
+    [issueIds]
+  );
+
+  useEffect(() => {
+    const field = fieldRef.current;
+    if (!field || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      setFieldLayoutVersion((current) => current + 1);
+    });
+    observer.observe(field);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const lanes = lanesRef.current;
+    if (!lanes) {
+      return;
+    }
+    let frame = 0;
+    function handleScroll() {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        setFieldLayoutVersion((current) => current + 1);
+      });
+    }
+    lanes.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      lanes.removeEventListener("scroll", handleScroll);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleResize() {
+      setFieldLayoutVersion((current) => current + 1);
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  useLayoutEffect(() => {
+    const field = fieldRef.current;
+    if (!field || !payload) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      const fieldRect = field.getBoundingClientRect();
+      const next: Record<string, { left: number; top: number }> = {};
+      for (const agent of payload.agents) {
+        const anchor = anchorRefs.current.get(anchorKeyForAgent(agent));
+        if (!anchor) {
+          continue;
+        }
+        const rect = anchor.getBoundingClientRect();
+        next[agent.agent_id] = {
+          left: rect.left - fieldRect.left + rect.width / 2,
+          top: rect.top - fieldRect.top + rect.height / 2,
+        };
+      }
+      setAgentPositions((current) => {
+        let changed = Object.keys(current).length !== Object.keys(next).length;
+        if (!changed) {
+          for (const [agentId, nextPosition] of Object.entries(next)) {
+            const currentPosition = current[agentId];
+            if (
+              !currentPosition ||
+              Math.abs(currentPosition.left - nextPosition.left) > 0.5 ||
+              Math.abs(currentPosition.top - nextPosition.top) > 0.5
+            ) {
+              changed = true;
+              break;
+            }
+          }
+        }
+        return changed ? next : current;
+      });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [anchorKeyForAgent, fieldLayoutVersion, payload]);
+
+  function anchorRef(key: string) {
+    return (node: HTMLDivElement | null) => {
+      if (node) {
+        anchorRefs.current.set(key, node);
+      } else {
+        anchorRefs.current.delete(key);
+      }
+    };
+  }
+
   function focusIssue(issue: TheaterIssue) {
     setSelectedIssueId(issue.task_id);
     setSelectedAgentId(issue.agent_id ?? null);
@@ -174,12 +355,14 @@ export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => 
     setSelectedAgentId(agent.agent_id);
     setSelectedIssueId(agent.current_task_id ?? null);
     setSelectedRunId(agent.current_run_id ?? null);
+    setSelectedBranchId(agent.current_task_id ? issueToBranch.get(agent.current_task_id) ?? null : null);
   }
 
   function focusRun(run: TheaterRun) {
     setSelectedRunId(run.run_id);
     setSelectedIssueId(run.task_id ?? null);
     setSelectedAgentId(run.agent_id ?? null);
+    setSelectedBranchId(run.task_id ? issueToBranch.get(run.task_id) ?? null : null);
   }
 
   return (
@@ -242,64 +425,150 @@ export function TheaterPage({ onNavigate }: { onNavigate: (view: ViewTarget) => 
             to act.
           </span>
         </div>
-        <div className="codex-theater-lanes" role="list" aria-label="Execution lanes">
-          {(payload?.layout.issue_lanes ?? []).map((lane) => {
-            const laneIssues = issuesByLane.get(lane.key) ?? [];
-            return (
-              <section key={lane.key} className="codex-theater-lane" role="listitem">
-                <header className="codex-theater-lane__header">
-                  <strong>{lane.label}</strong>
-                  <span>{laneIssues.length}</span>
-                </header>
-                <div className="codex-theater-lane__body">
-                  {laneIssues.length ? (
-                    laneIssues.map((issue) => {
-                      const isSelected =
-                        selectedIssue?.task_id === issue.task_id ||
-                        selectedBranch?.task_id === issue.task_id ||
-                        selectedRun?.task_id === issue.task_id ||
-                        selectedAgent?.current_task_id === issue.task_id;
-                      return (
-                        <button
-                          key={issue.task_id}
-                          type="button"
-                          className={`codex-theater-card codex-theater-card--${issueTone(issue)} ${isSelected ? "is-selected" : ""}`}
-                          onClick={() => focusIssue(issue)}
-                        >
-                          <div className="codex-theater-card__top">
-                            <span className="codex-theater-card__issue-key">{issue.issue_key ?? issue.task_id}</span>
-                            <span className={`codex-status-chip codex-status-chip--${issue.status}`}>
-                              {statusLabel(issue.status, issue.review_state)}
-                            </span>
-                          </div>
-                          <strong>{issue.title}</strong>
-                          <p>
-                            {issue.blocked_reason
-                              ? issue.blocked_reason.replaceAll("_", " ")
-                              : issue.delivery_summary ?? issue.goal_title ?? "No additional execution summary."}
-                          </p>
-                          <div className="codex-theater-card__meta">
-                            <span>{priorityLabel(issue.priority)}</span>
-                            <span>{issue.agent_name ?? "Unassigned"}</span>
-                            <span>{issue.current_run_status?.replaceAll("_", " ") ?? "No run"}</span>
-                          </div>
-                          <div className="codex-theater-card__chips">
-                            {issue.git_workspace_branch ? <span className="codex-chip">{issue.git_workspace_branch}</span> : null}
-                            {issue.latest_verification_status ? (
-                              <span className="codex-chip">Verify: {issue.latest_verification_status}</span>
-                            ) : null}
-                            {issue.delivery_state ? <span className="codex-chip">Delivery: {issue.delivery_state}</span> : null}
-                          </div>
-                        </button>
-                      );
-                    })
-                  ) : (
-                    <div className="codex-empty-copy">No issues in this lane.</div>
-                  )}
-                </div>
-              </section>
-            );
-          })}
+        <div className="codex-theater-field" ref={fieldRef}>
+          <div className="codex-theater-agent-dock">
+            <header className="codex-theater-agent-dock__header">
+              <strong>Agent motion</strong>
+              <span>{payload?.agents.length ?? 0} live tokens attach to issue ownership and runtime changes</span>
+            </header>
+            <div className="codex-theater-agent-dock__grid">
+              {THEATER_DOCK_ORDER.map((dockState) => {
+                const agents = fieldAgents.docked[dockState];
+                return (
+                  <section key={dockState} className="codex-theater-agent-dock__group">
+                    <header className="codex-theater-agent-dock__group-header">
+                      <strong>{THEATER_DOCK_LABELS[dockState]}</strong>
+                      <span>{agents.length}</span>
+                    </header>
+                    <div className="codex-theater-agent-dock__slots">
+                      {agents.length ? (
+                        agents.map((agent) => (
+                          <div
+                            key={agent.agent_id}
+                            ref={anchorRef(`dock:${dockState}:${agent.agent_id}`)}
+                            className={`codex-theater-agent-anchor codex-theater-agent-anchor--${agentTone(agent)}`}
+                          />
+                        ))
+                      ) : (
+                        <div className="codex-empty-copy">No agents in this posture.</div>
+                      )}
+                    </div>
+                  </section>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="codex-theater-lanes" role="list" aria-label="Execution lanes" ref={lanesRef}>
+            {(payload?.layout.issue_lanes ?? []).map((lane) => {
+              const laneIssues = issuesByLane.get(lane.key) ?? [];
+              return (
+                <section key={lane.key} className="codex-theater-lane" role="listitem">
+                  <header className="codex-theater-lane__header">
+                    <strong>{lane.label}</strong>
+                    <span>{laneIssues.length}</span>
+                  </header>
+                  <div className="codex-theater-lane__body">
+                    {laneIssues.length ? (
+                      laneIssues.map((issue) => {
+                        const isSelected =
+                          selectedIssue?.task_id === issue.task_id ||
+                          selectedBranch?.task_id === issue.task_id ||
+                          selectedRun?.task_id === issue.task_id ||
+                          selectedAgent?.current_task_id === issue.task_id;
+                        const assignedAgents = fieldAgents.attached.get(issue.task_id) ?? [];
+                        return (
+                          <button
+                            key={issue.task_id}
+                            type="button"
+                            className={`codex-theater-card codex-theater-card--${issueTone(issue)} ${isSelected ? "is-selected" : ""}`}
+                            onClick={() => focusIssue(issue)}
+                          >
+                            <div className="codex-theater-card__top">
+                              <span className="codex-theater-card__issue-key">{issue.issue_key ?? issue.task_id}</span>
+                              <span className={`codex-status-chip codex-status-chip--${issue.status}`}>
+                                {statusLabel(issue.status, issue.review_state)}
+                              </span>
+                            </div>
+                            <strong>{issue.title}</strong>
+                            <p>
+                              {issue.blocked_reason
+                                ? issue.blocked_reason.replaceAll("_", " ")
+                                : issue.delivery_summary ?? issue.goal_title ?? "No additional execution summary."}
+                            </p>
+                            <div className="codex-theater-card__meta">
+                              <span>{priorityLabel(issue.priority)}</span>
+                              <span>{issue.agent_name ?? "Unassigned"}</span>
+                              <span>{issueRunLabel(issue)}</span>
+                            </div>
+                            <div className="codex-theater-card__chips">
+                              {issue.git_workspace_branch ? <span className="codex-chip">{issue.git_workspace_branch}</span> : null}
+                              {issue.latest_verification_status ? (
+                                <span className="codex-chip">Verify: {issue.latest_verification_status}</span>
+                              ) : null}
+                              {issue.delivery_state ? <span className="codex-chip">Delivery: {issue.delivery_state}</span> : null}
+                            </div>
+                            <div className="codex-theater-card__agent-row">
+                              <div className="codex-theater-card__agent-copy">
+                                <strong>Agent slots</strong>
+                                <span>
+                                  {assignedAgents.length
+                                    ? `${assignedAgents.length} attached ${assignedAgents.length === 1 ? "token" : "tokens"}`
+                                    : "Awaiting ownership"}
+                                </span>
+                              </div>
+                              <div className="codex-theater-card__agent-slots" aria-hidden="true">
+                                {assignedAgents.length ? (
+                                  assignedAgents.map((agent) => (
+                                    <div
+                                      key={agent.agent_id}
+                                      ref={anchorRef(`issue:${issue.task_id}:${agent.agent_id}`)}
+                                      className={`codex-theater-agent-anchor codex-theater-agent-anchor--${agentTone(agent)}`}
+                                    />
+                                  ))
+                                ) : (
+                                  <div className="codex-theater-agent-anchor codex-theater-agent-anchor--empty" />
+                                )}
+                              </div>
+                            </div>
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <div className="codex-empty-copy">No issues in this lane.</div>
+                    )}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+
+          <div className="codex-theater-agent-overlay">
+            {(payload?.agents ?? []).map((agent) => {
+              const position = agentPositions[agent.agent_id];
+              const linkedRun = agent.current_run_id ? runsById.get(agent.current_run_id) ?? null : null;
+              const isSelected =
+                selectedAgent?.agent_id === agent.agent_id ||
+                selectedIssue?.task_id === agent.current_task_id ||
+                selectedRun?.agent_id === agent.agent_id;
+              if (!position) {
+                return null;
+              }
+              return (
+                <button
+                  key={agent.agent_id}
+                  type="button"
+                  className={`codex-theater-agent-token codex-theater-agent-token--${agentTone(agent)} ${isSelected ? "is-selected" : ""}`}
+                  style={{ left: position.left, top: position.top }}
+                  onClick={() => focusAgent(agent)}
+                  aria-label={`Focus agent ${agent.name}`}
+                >
+                  <strong>{agent.name}</strong>
+                  <span>{agentStatusLabel(agent, linkedRun)}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5580,6 +5580,79 @@ body {
   gap: 14px;
 }
 
+.codex-theater-field {
+  position: relative;
+  display: grid;
+  gap: 16px;
+}
+
+.codex-theater-agent-dock {
+  display: grid;
+  gap: 12px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--line) 84%, transparent 16%);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 16%, transparent), transparent 44%),
+    color-mix(in srgb, var(--panel) 95%, transparent 5%);
+  padding: 14px;
+}
+
+.codex-theater-agent-dock__header,
+.codex-theater-agent-dock__group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.codex-theater-agent-dock__grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.codex-theater-agent-dock__group {
+  display: grid;
+  gap: 10px;
+}
+
+.codex-theater-agent-dock__slots,
+.codex-theater-card__agent-slots {
+  display: flex;
+  min-height: 54px;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.codex-theater-agent-anchor {
+  width: 116px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px dashed color-mix(in srgb, var(--line) 72%, transparent 28%);
+  background: color-mix(in srgb, var(--panel-strong) 84%, transparent 16%);
+}
+
+.codex-theater-agent-anchor--good {
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--line));
+}
+
+.codex-theater-agent-anchor--warn {
+  border-color: color-mix(in srgb, var(--warning) 42%, var(--line));
+}
+
+.codex-theater-agent-anchor--danger {
+  border-color: color-mix(in srgb, var(--danger) 44%, var(--line));
+}
+
+.codex-theater-agent-anchor--empty {
+  width: 100%;
+  min-width: 120px;
+  opacity: 0.56;
+}
+
 .codex-theater-lanes {
   display: grid;
   gap: 14px;
@@ -5667,6 +5740,87 @@ body {
   flex-wrap: wrap;
   color: var(--muted);
   font-size: 0.8rem;
+}
+
+.codex-theater-card__agent-row {
+  display: grid;
+  gap: 8px;
+  margin-top: 2px;
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in srgb, var(--line) 82%, transparent 18%);
+}
+
+.codex-theater-card__agent-copy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.codex-theater-agent-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: clip;
+}
+
+.codex-theater-agent-token {
+  position: absolute;
+  display: grid;
+  gap: 2px;
+  min-width: 116px;
+  max-width: 152px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--line) 70%, transparent 30%);
+  background: color-mix(in srgb, var(--panel-strong) 96%, transparent 4%);
+  padding: 9px 12px;
+  box-shadow: 0 14px 34px rgba(12, 18, 32, 0.14);
+  color: inherit;
+  text-align: left;
+  transform: translate(-50%, -50%);
+  transition:
+    left 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    top 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    background 140ms ease;
+  pointer-events: auto;
+}
+
+.codex-theater-agent-token strong {
+  font-size: 0.82rem;
+}
+
+.codex-theater-agent-token span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-transform: capitalize;
+}
+
+.codex-theater-agent-token.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--line));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent), 0 16px 40px rgba(12, 18, 32, 0.16);
+}
+
+.codex-theater-agent-token--good {
+  background: color-mix(in srgb, var(--accent-soft) 72%, var(--panel-strong));
+}
+
+.codex-theater-agent-token--warn {
+  background: color-mix(in srgb, var(--warning-soft) 78%, var(--panel-strong));
+}
+
+.codex-theater-agent-token--danger {
+  background: color-mix(in srgb, var(--danger-soft) 78%, var(--panel-strong));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .codex-theater-agent-token,
+  .codex-theater-card {
+    transition: none;
+  }
 }
 
 .codex-theater-bottom {
@@ -5767,6 +5921,10 @@ body {
   .codex-resolved-list,
   .codex-detail-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .codex-theater-agent-dock__grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary\n- turn Theater into a true execution field with agent-token anchors, docked off-field posture, and synchronized focus routing\n- animate token movement only when ownership or runtime targets change, with scroll-aware remeasurement and reduced-motion fallback\n- document the batch in the implementation history and link the new Theater slice from the current-truth docs\n\n## Validation\n- 
> maas-web@0.1.0 build
> tsc -b && vite build

vite v6.4.1 building for production...
transforming...
✓ 54 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.40 kB │ gzip:   0.27 kB
dist/assets/index-C3D9_tYu.css   95.42 kB │ gzip:  15.30 kB
dist/assets/index-CZz32Vc-.js   444.89 kB │ gzip: 115.12 kB
✓ built in 948ms\n- \n\n## Review\n- subagent review found and I fixed: stale token alignment on horizontal scroll, missing reduced-motion handling, off-field working agents being misclassified as idle, and partial multi-agent selection highlighting\n- follow-up subagent re-check found no remaining actionable issues in the reviewed scope\n\nCloses #120