### PR TITLE
Implement Batch #133 unattended trust final closure and gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Relevant design and roadmap documents:
 - [Unattended Local Trust v1: Idempotent Side Effects and Retry Safety](docs/implementation/32-unattended-local-trust-idempotent-side-effects.md)
 - [Unattended Local Trust v1: Stop States and Operator Truth](docs/implementation/33-unattended-local-trust-stop-states-operator-truth.md)
 - [Unattended Local Trust v1: Overnight Soak and Fault Injection](docs/implementation/34-unattended-local-trust-soak-fault-injection.md)
+- [Unattended Local Trust v1: Final Closure and Trust Gate](docs/implementation/35-unattended-local-trust-final-closure-gate.md)
 
 There is also a standalone product mockup for the current direction in [mockups/maas-codex-mvp/README.md](mockups/maas-codex-mvp/README.md).
 
@@ -160,6 +161,8 @@ Active planning and execution now live in GitHub, not in the numbered implementa
 - history/reference docs: the numbered implementation docs under [docs/implementation](docs/implementation/)
 
 Use one GitHub issue per tracked task or roadmap item, keep project fields truthful, and link the PR once code work starts. Reconciliation now also repairs stale merged-state cards for this repo's own GitHub Project when a tracked issue is already closed by a merged PR.
+
+For unattended local use, rely on the System surface trust gate rather than README prose. MAAS now exposes an explicit unattended-mode gate that only arms after a fresh passing trust soak, clean truth reconciliation, and healthy launch posture.
 
 ## Roadmap and Implementation History
 

--- a/docs/implementation/35-unattended-local-trust-final-closure-gate.md
+++ b/docs/implementation/35-unattended-local-trust-final-closure-gate.md
@@ -1,0 +1,81 @@
+Status: implemented as unattended-local-trust batch issue `#133`.
+
+# Unattended Local Trust v1: Final Closure and Trust Gate
+
+## Goal
+
+Close the last gap between “we can run fault-injected trust soaks” and “MAAS can truthfully tell the operator whether this project is safe to leave unattended overnight right now.”
+
+## What shipped
+
+- `src/maas/services/trust_gate.py`
+  - adds the unattended trust gate
+  - derives eligibility from the latest persisted trust run, current truth warnings, autopilot posture, and launch posture
+  - exposes explicit statuses:
+    - `unverified`
+    - `blocked`
+    - `eligible`
+    - `armed`
+    - `armed_blocked`
+  - blocks intentional unattended mode until the project is actually eligible
+- `src/maas/services/trust_runs.py`
+  - trust soak cycles now reconcile after each injected cycle
+  - trust reports distinguish tolerated canonical stop-state holds from genuine unreconciled truth mismatches
+  - a passing soak now means “the control loop stayed truthful after repair,” not merely “the cycle finished”
+- `src/maas/api.py`
+  - adds `POST /api/projects/{project_id}/actions/update-unattended-mode`
+- `src/maas/services/codex_mvp.py`
+  - System diagnostics now include `trust_gate`
+- `web/src/pages/CodexSystemPage.tsx`
+  - System now shows:
+    - trust gate status
+    - exact blockers
+    - direct arm/disarm control
+    - existing trust soak history underneath the gate
+- `web/src/lib/controlRoomApi.ts`
+  - adds project unattended-mode update support
+
+## Why this matters
+
+The previous batch could prove that MAAS survives deterministic injected failures and record replayable incidents, but it still left one practical question unanswered:
+
+- “Can I leave this project unattended tonight?”
+
+This batch makes that answer explicit, durable, and operator-visible.
+
+## Trust gate rules
+
+The project is only `eligible` when:
+
+- the latest trust soak completed successfully
+- the latest trust soak report is `passed`
+- the soak covered at least the required cycle count
+- the soak evidence is still fresh
+- no duplicate side effects were recorded
+- no unreconciled truth mismatches remain
+- autopilot is enabled
+- launch posture is `running`
+- provider capacity is above zero
+
+If the operator tries to arm unattended mode before those conditions hold, MAAS rejects the request and reports the blockers directly.
+
+## Final closure behavior
+
+- arming unattended mode first runs reconciliation
+- reconciliation remains the canonical path for:
+  - truth repair
+  - delivery refresh
+  - GitHub project truth sync
+- the trust gate uses that repaired state rather than stale pre-reconcile drift
+
+## Validation
+
+- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_trust_gate_api.py -q`
+- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_trust_runs_api.py -q`
+- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_reconciliation_api.py -q -k "system_diagnostics_and_theater_surface_truth_warnings"`
+- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_codex_mvp_api.py -q -k "system_diagnostics_include_run_observability_and_suppression"`
+- `cd web && npm run build`
+
+## Outcome
+
+With this batch, unattended-local-trust v1 is no longer just a collection of mechanisms. MAAS now exposes one explicit go/no-go signal for unattended overnight use and refuses intentional unattended mode until the trust prerequisites are green.

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -48,6 +48,7 @@ Rules:
 
 `main` now includes the shipped post-`#224` slices through `#234`. Follow-on batch planning now lives in GitHub issues and the project board instead of new active-plan docs.
 The current unattended-local-trust hardening program is tracked in GitHub batches `#129-#133`, with Batch `#129` establishing reconciliation-backed truth inspection and repair, Batch `#130` making notification, provider, git-workspace, and GitHub-sync side effects retry-safe and idempotent, Batch `#131` making stop states and board truth canonical, and Batch `#132` adding persisted trust runs, deterministic fault injection, replayable incidents, and operator-visible soak reports.
+Batch `#133` closes that program by adding the unattended trust gate itself: MAAS now derives explicit overnight eligibility from passing soak evidence plus current launch/truth posture, and it refuses intentional unattended mode until those prerequisites are actually green.
 
 See:
 
@@ -77,6 +78,7 @@ See:
 - [32-unattended-local-trust-idempotent-side-effects.md](32-unattended-local-trust-idempotent-side-effects.md)
 - [33-unattended-local-trust-stop-states-operator-truth.md](33-unattended-local-trust-stop-states-operator-truth.md)
 - [34-unattended-local-trust-soak-fault-injection.md](34-unattended-local-trust-soak-fault-injection.md)
+- [35-unattended-local-trust-final-closure-gate.md](35-unattended-local-trust-final-closure-gate.md)
 - [mockups/maas-codex-mvp/README.md](../../mockups/maas-codex-mvp/README.md)
 
 ## GitHub Project Contract

--- a/src/maas/api.py
+++ b/src/maas/api.py
@@ -117,6 +117,7 @@ from maas.services.steering import (
 )
 from maas.services.system_dialogs import pick_directory_via_native_dialog
 from maas.services.theater import fetch_theater
+from maas.services.trust_gate import update_project_unattended_mode
 from maas.services.trust_runs import execute_trust_run
 from maas.supervisor import run_supervisor_once
 from maas.services.timeline import fetch_incident_timeline
@@ -201,6 +202,11 @@ class SystemTrustRunRequest(BaseModel):
     project_id: Optional[str] = None
     cycle_limit: int = 6
     sleep_seconds: int = 0
+
+
+class ProjectUnattendedModeRequest(BaseModel):
+    actor_id: str = "agent_allocator"
+    enabled: bool
 
 
 class AlertActionRequest(BaseModel):
@@ -733,6 +739,24 @@ def create_app(project_root=".", enable_lifespan_autopilot=True):
                     "max_repeated_failure_incidents": payload.max_repeated_failure_incidents,
                     "max_notification_failures": payload.max_notification_failures,
                 },
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        finally:
+            connection.close()
+
+    @app.post("/api/projects/{project_id}/actions/update-unattended-mode")
+    def projects_update_unattended_mode(project_id: str, payload: ProjectUnattendedModeRequest):
+        connection = connect(paths)
+        try:
+            return update_project_unattended_mode(
+                connection,
+                paths,
+                project_id,
+                payload.actor_id,
+                payload.enabled,
             )
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc))

--- a/src/maas/config.py
+++ b/src/maas/config.py
@@ -280,6 +280,11 @@ def build_default_project_config(
             "daily_runtime_seconds_limit": 0,
             "max_task_session_attempts": 0,
         },
+        "trust": {
+            "unattended_mode_requested": False,
+            "required_passed_cycles": 6,
+            "max_trust_run_age_hours": 24,
+        },
     }
 
 

--- a/src/maas/services/codex_mvp.py
+++ b/src/maas/services/codex_mvp.py
@@ -16,6 +16,7 @@ from maas.services.repo_plan import build_brownfield_grounding
 from maas.services.review_policy import evaluate_review_decision_state, fetch_project_review_policy
 from maas.services.stop_states import issue_stop_state, run_stop_state, stale_agent_stop_state
 from maas.services.timeline import fetch_incident_timeline
+from maas.services.trust_gate import fetch_project_unattended_trust
 from maas.services.trust_runs import fetch_latest_trust_run_summary
 from maas.services.verification import fetch_verification_runs
 
@@ -945,6 +946,7 @@ def fetch_system_diagnostics(connection, project_id, project_paths=None):
             }
         )
     trust_run = fetch_latest_trust_run_summary(connection, project_id)
+    trust_gate = fetch_project_unattended_trust(connection, project_paths, project_id)
 
     return {
         "summary": {
@@ -977,6 +979,7 @@ def fetch_system_diagnostics(connection, project_id, project_paths=None):
         },
         "truth": truth,
         "trust_run": trust_run,
+        "trust_gate": trust_gate,
     }
 
 

--- a/src/maas/services/trust_gate.py
+++ b/src/maas/services/trust_gate.py
@@ -1,0 +1,381 @@
+"""Unattended local trust eligibility and mode control."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+from maas.ids import generate_id
+from maas.services.github_project_sync import inspect_github_project_truth
+from maas.services.operator_actions import project_autopilot_action, project_launch_posture_action
+from maas.services.projects import resolve_project, resolve_project_id
+from maas.services.queue_capacity import queue_capacity_snapshot
+from maas.services.reconciliation import inspect_project_truth, reconcile_project_truth
+from maas.services.security import ensure_board_action_allowed
+from maas.services.trust_runs import DEFAULT_TRUST_RUN_CYCLE_LIMIT, fetch_latest_trust_run_summary
+
+
+DEFAULT_TRUST_MAX_AGE_HOURS = 24
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+def _utc_now_iso():
+    return _utc_now().isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value):
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _age_seconds(value):
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return None
+    return max(0, int((_utc_now() - parsed).total_seconds()))
+
+
+def _load_json(value):
+    try:
+        payload = json.loads(value or "{}")
+    except (TypeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _trust_config(project_row):
+    config = _load_json(project_row["config_json"] if project_row else "{}")
+    trust = dict(config.get("trust") or {})
+    trust.setdefault("unattended_mode_requested", False)
+    trust.setdefault("required_passed_cycles", DEFAULT_TRUST_RUN_CYCLE_LIMIT)
+    trust.setdefault("max_trust_run_age_hours", DEFAULT_TRUST_MAX_AGE_HOURS)
+    return config, trust
+
+
+def _blocker(code, summary, detail, *, severity="warning", operator_actions=None):
+    item = {
+        "code": code,
+        "summary": summary,
+        "detail": detail,
+        "severity": severity,
+    }
+    if operator_actions:
+        item["operator_actions"] = operator_actions
+    return item
+
+
+def fetch_project_unattended_trust(connection, project_paths, project_id=None, *, include_remote_board=False):
+    resolved_project_id = resolve_project_id(connection, project_id, include_archived=False)
+    if resolved_project_id is None:
+        raise ValueError("project not found")
+    project_row = resolve_project(connection, resolved_project_id, include_archived=False)
+    config, trust_config = _trust_config(project_row)
+    trust_run = fetch_latest_trust_run_summary(connection, resolved_project_id)
+    truth = inspect_project_truth(connection, project_paths, resolved_project_id)
+    from maas.services.autopilot import fetch_project_autopilot_policy
+
+    autopilot_policy = fetch_project_autopilot_policy(connection, resolved_project_id)
+    queue_snapshot = queue_capacity_snapshot(connection, resolved_project_id)
+    blockers = []
+
+    required_cycles = max(1, int(trust_config.get("required_passed_cycles") or DEFAULT_TRUST_RUN_CYCLE_LIMIT))
+    max_age_hours = max(1, int(trust_config.get("max_trust_run_age_hours") or DEFAULT_TRUST_MAX_AGE_HOURS))
+    unattended_requested = bool(trust_config.get("unattended_mode_requested"))
+
+    if trust_run is None:
+        blockers.append(
+            _blocker(
+                "trust_evidence_missing",
+                "No unattended trust soak has been recorded.",
+                "Run the trust soak before arming unattended mode so MAAS has current failure-injection evidence for this project.",
+                severity="critical",
+            )
+        )
+    else:
+        report = trust_run.get("report") or {}
+        completed_cycles = int(report.get("completed_cycles") or trust_run.get("completed_cycles") or 0)
+        if trust_run.get("status") != "completed":
+            blockers.append(
+                _blocker(
+                    "trust_run_incomplete",
+                    "The latest trust soak did not complete.",
+                    "Wait for the current soak to finish or rerun it before arming unattended mode.",
+                    severity="critical",
+                )
+            )
+        if (report.get("status") or "").lower() != "passed":
+            blockers.append(
+                _blocker(
+                    "trust_run_not_passing",
+                    "The latest trust soak still reports unresolved trust issues.",
+                    "Clear the remaining trust blockers and rerun the soak until the report passes cleanly.",
+                    severity="critical",
+                )
+            )
+        if completed_cycles < required_cycles:
+            blockers.append(
+                _blocker(
+                    "trust_run_insufficient_coverage",
+                    "The latest trust soak did not cover enough cycles.",
+                    "Increase the trust run to at least {0} completed cycles before relying on unattended mode.".format(required_cycles),
+                    severity="warning",
+                )
+            )
+        age_seconds = _age_seconds(trust_run.get("ended_at") or trust_run.get("started_at"))
+        if age_seconds is None or age_seconds > max_age_hours * 3600:
+            blockers.append(
+                _blocker(
+                    "trust_run_stale",
+                    "The latest trust soak evidence is stale.",
+                    "Rerun the trust soak. Overnight trust evidence older than {0} hours is treated as stale.".format(max_age_hours),
+                    severity="warning",
+                )
+            )
+        if int(report.get("duplicate_side_effects") or 0) > 0:
+            blockers.append(
+                _blocker(
+                    "duplicate_side_effects_detected",
+                    "The latest trust soak detected duplicate external side effects.",
+                    "Resolve duplicate PR, notification, workspace, or provider side effects before relying on unattended mode.",
+                    severity="critical",
+                )
+            )
+        if int(report.get("unreconciled_truth_mismatches") or 0) > 0:
+            blockers.append(
+                _blocker(
+                    "trust_truth_mismatch",
+                    "The latest trust soak ended with unreconciled truth mismatches.",
+                    "Run reconciliation and fix the remaining stale truth before arming unattended mode.",
+                    severity="critical",
+                )
+            )
+
+    if int(truth["summary"].get("warning_count") or 0) > 0:
+        blockers.append(
+            _blocker(
+                "live_truth_drift",
+                "Project truth still has active warnings.",
+                "Reconcile the project truth and clear stale run, task, or agent linkage before leaving MAAS unattended.",
+                severity="critical",
+            )
+        )
+
+    if not autopilot_policy.get("enabled"):
+        blockers.append(
+            _blocker(
+                "autopilot_disabled",
+                "Autopilot is disabled.",
+                "Enable autopilot before arming unattended mode; otherwise the project will not keep advancing on its own.",
+                severity="warning",
+                operator_actions=[
+                    project_autopilot_action(
+                        resolved_project_id,
+                        "Enable autopilot",
+                        {**autopilot_policy, "enabled": True},
+                    )
+                ],
+            )
+        )
+
+    if queue_snapshot.get("queue_mode") != "running":
+        blockers.append(
+            _blocker(
+                "launch_posture_not_running",
+                "Launch posture is not set to running.",
+                "Resume launches before arming unattended mode so new work can actually start without operator intervention.",
+                severity="warning",
+                operator_actions=[
+                    project_launch_posture_action(
+                        resolved_project_id,
+                        "Resume launches",
+                        "running",
+                        queue_snapshot.get("max_running_jobs") or 1,
+                        queue_snapshot.get("preferred_provider_id"),
+                    )
+                ],
+            )
+        )
+
+    if int(queue_snapshot.get("max_running_jobs") or 0) <= 0:
+        blockers.append(
+            _blocker(
+                "zero_launch_capacity",
+                "Provider capacity is zero.",
+                "Increase max running jobs above zero before arming unattended mode.",
+                severity="critical",
+                operator_actions=[
+                    project_launch_posture_action(
+                        resolved_project_id,
+                        "Restore provider capacity",
+                        "running",
+                        1,
+                        queue_snapshot.get("preferred_provider_id"),
+                    )
+                ],
+            )
+        )
+
+    project_board = None
+    if include_remote_board:
+        project_board = inspect_github_project_truth(connection, resolved_project_id)
+        if project_board.get("enabled") and not project_board.get("skipped"):
+            if project_board.get("warnings"):
+                blockers.append(
+                    _blocker(
+                        "project_board_sync_failed",
+                        "GitHub project truth could not be verified cleanly.",
+                        project_board["warnings"][0].get("detail") or "The execution board could not be checked cleanly.",
+                        severity="warning",
+                    )
+                )
+            elif int(project_board.get("drift_count") or 0) > 0:
+                blockers.append(
+                    _blocker(
+                        "project_board_drift",
+                        "GitHub project truth is still stale.",
+                        "Reconcile the project board so merged execution state matches the GitHub issue cards before arming unattended mode.",
+                        severity="warning",
+                    )
+                )
+
+    eligible = not blockers
+    if unattended_requested and eligible:
+        status = "armed"
+        summary = "Unattended mode is armed."
+        detail = "MAAS has current trust evidence and no live blockers that would make overnight autonomy unsafe right now."
+    elif unattended_requested:
+        status = "armed_blocked"
+        summary = "Unattended mode was requested, but current blockers make it unsafe."
+        detail = "MAAS will not treat this project as safe for unattended use until the blockers below are cleared."
+    elif eligible:
+        status = "eligible"
+        summary = "This project is eligible for unattended mode."
+        detail = "The latest trust soak passed, launch posture is healthy, and MAAS has no active truth drift for this project."
+    elif trust_run is None or any(item["code"].startswith("trust_run") or item["code"] == "trust_evidence_missing" for item in blockers):
+        status = "unverified"
+        summary = "This project is not yet verified for unattended mode."
+        detail = "Trust evidence is missing, stale, incomplete, or still failing. Rerun the trust soak after clearing the listed blockers."
+    else:
+        status = "blocked"
+        summary = "This project has current blockers for unattended mode."
+        detail = "The trust evidence may be present, but the live control loop still has blockers that should be cleared before you leave MAAS unattended."
+
+    return {
+        "project_id": resolved_project_id,
+        "status": status,
+        "eligible": eligible,
+        "unattended_mode_requested": unattended_requested,
+        "summary": summary,
+        "detail": detail,
+        "checked_at": _utc_now_iso(),
+        "required_passed_cycles": required_cycles,
+        "max_trust_run_age_hours": max_age_hours,
+        "latest_trust_run_id": (trust_run or {}).get("trust_run_id"),
+        "latest_trust_run_status": (trust_run or {}).get("status"),
+        "latest_trust_run_finished_at": (trust_run or {}).get("ended_at"),
+        "truth_warning_count": int(truth["summary"].get("warning_count") or 0),
+        "project_board": {
+            "enabled": bool((project_board or {}).get("enabled")),
+            "drift_count": int((project_board or {}).get("drift_count") or 0),
+            "updated_count": int((project_board or {}).get("updated_count") or 0),
+            "warnings": (project_board or {}).get("warnings") or [],
+        },
+        "blockers": blockers,
+    }
+
+
+def update_project_unattended_mode(connection, project_paths, project_id, actor_id, enabled):
+    resolved_project_id = resolve_project_id(connection, project_id, include_archived=False)
+    if resolved_project_id is None:
+        raise ValueError("project not found")
+    actor = ensure_board_action_allowed(
+        connection,
+        actor_id,
+        resolved_project_id,
+        "update_unattended_mode",
+        "project",
+        resolved_project_id,
+    )
+    project_row = resolve_project(connection, resolved_project_id, include_archived=False)
+    if project_row is None:
+        raise ValueError("project not found")
+    config, trust_config = _trust_config(project_row)
+
+    if enabled:
+        reconcile_project_truth(
+            connection,
+            project_paths,
+            project_id=resolved_project_id,
+            actor_id=actor["actor_id"],
+            source="unattended_mode_arm",
+        )
+        gate = fetch_project_unattended_trust(
+            connection,
+            project_paths,
+            resolved_project_id,
+            include_remote_board=True,
+        )
+        if not gate["eligible"]:
+            raise ValueError(gate["summary"])
+    else:
+        gate = fetch_project_unattended_trust(connection, project_paths, resolved_project_id)
+
+    trust_config["unattended_mode_requested"] = bool(enabled)
+    trust_config["last_mode_changed_at"] = _utc_now_iso()
+    if enabled:
+        trust_config["last_armed_at"] = trust_config["last_mode_changed_at"]
+    else:
+        trust_config["last_disarmed_at"] = trust_config["last_mode_changed_at"]
+    config["trust"] = trust_config
+
+    connection.execute(
+        "UPDATE projects SET config_json = ?, updated_at = CURRENT_TIMESTAMP WHERE project_id = ?",
+        (json.dumps(config), resolved_project_id),
+    )
+    connection.execute(
+        """
+        INSERT INTO audit_trail (
+            audit_id, project_id, actor_id, action_type, resource_type, resource_id, detail_json
+        ) VALUES (?, ?, ?, ?, 'project', ?, ?)
+        """,
+        (
+            generate_id("audit"),
+            resolved_project_id,
+            actor["actor_id"],
+            "update_unattended_mode",
+            resolved_project_id,
+            json.dumps(
+                {
+                    "enabled": bool(enabled),
+                    "trust_gate_status": gate["status"],
+                    "eligible": gate["eligible"],
+                    "blocker_codes": [item["code"] for item in gate["blockers"]],
+                }
+            ),
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO activity_log (
+            activity_id, project_id, action, category, description, details_json, severity
+        ) VALUES (?, ?, 'unattended_mode_updated', 'projects', ?, ?, 'info')
+        """,
+        (
+            generate_id("act"),
+            resolved_project_id,
+            "Armed unattended mode." if enabled else "Disarmed unattended mode.",
+            json.dumps({"enabled": bool(enabled), "actor_id": actor["actor_id"]}),
+        ),
+    )
+    connection.commit()
+    return fetch_project_unattended_trust(connection, project_paths, resolved_project_id, include_remote_board=bool(enabled))

--- a/src/maas/services/trust_runs.py
+++ b/src/maas/services/trust_runs.py
@@ -21,6 +21,10 @@ from maas.services.security import ensure_board_action_allowed
 
 DEFAULT_TRUST_RUN_PROFILE = "default"
 DEFAULT_TRUST_RUN_CYCLE_LIMIT = 6
+TRUST_TOLERATED_WARNING_CODES = {
+    "active_session_conflicts_with_task_state",
+    "active_session_conflicts_with_agent_state",
+}
 
 
 def _load_json(value):
@@ -513,6 +517,17 @@ def _build_report(cycle_limit):
     }
 
 
+def _effective_truth_warning_count(payload):
+    warnings = (payload or {}).get("warnings") or []
+    return len(
+        [
+            item
+            for item in warnings
+            if item.get("code") not in TRUST_TOLERATED_WARNING_CODES
+        ]
+    )
+
+
 def execute_trust_run(connection, project_paths, project_id, actor_id="agent_allocator", *, cycle_limit=DEFAULT_TRUST_RUN_CYCLE_LIMIT, sleep_seconds=0, profile=DEFAULT_TRUST_RUN_PROFILE):
     from maas.services.codex_mvp import fetch_system_diagnostics
     from maas.services.delivery import sync_github_pr
@@ -520,6 +535,7 @@ def execute_trust_run(connection, project_paths, project_id, actor_id="agent_all
     from maas.services.notifications import process_next_notification
     from maas.services.orchestrator import run_orchestrator_once
     from maas.services.provider_runtime import process_next_provider_job, queue_provider_task
+    from maas.services.reconciliation import reconcile_project_truth
 
     resolved_project_id = resolve_project_id(connection, project_id, include_archived=False)
     if resolved_project_id is None:
@@ -648,8 +664,7 @@ def execute_trust_run(connection, project_paths, project_id, actor_id="agent_all
             cycle_summary["orchestrator_project_runs"] = len(orchestrator_summary.get("project_runs") or [])
 
             diagnostics = fetch_system_diagnostics(connection, resolved_project_id, project_paths=project_paths)
-            cycle_summary["truth_warning_count"] = diagnostics["truth"]["summary"]["warning_count"]
-            cycle_summary["repair_count"] = diagnostics["truth"]["summary"]["repaired_count"]
+            cycle_summary["truth_warning_count_pre_reconcile"] = diagnostics["truth"]["summary"]["warning_count"]
             cycle_summary["blocking_stop_states"] = len(
                 [
                     item
@@ -657,17 +672,33 @@ def execute_trust_run(connection, project_paths, project_id, actor_id="agent_all
                     if (item.get("stop_state") or {}).get("autopilot_blocking")
                 ]
             )
+            reconciliation = reconcile_project_truth(
+                connection,
+                project_paths,
+                project_id=resolved_project_id,
+                actor_id=actor["actor_id"],
+                source="trust_soak_cycle",
+            )
+            diagnostics = fetch_system_diagnostics(connection, resolved_project_id, project_paths=project_paths)
+            cycle_summary["truth_warning_count_raw"] = diagnostics["truth"]["summary"]["warning_count"]
+            cycle_summary["truth_warning_count"] = _effective_truth_warning_count(reconciliation)
+            cycle_summary["tolerated_truth_warning_count"] = max(
+                0,
+                int(cycle_summary["truth_warning_count_raw"] or 0) - int(cycle_summary["truth_warning_count"] or 0),
+            )
+            cycle_summary["repair_count"] = reconciliation["summary"]["repaired_count"]
+            cycle_summary["project_board_sync_count"] = reconciliation["summary"].get("project_board_sync_count") or 0
             new_incidents = _capture_trust_run_incidents(connection, resolved_project_id, trust_run_id, diagnostics)
             cycle_summary["new_incidents"] = new_incidents
 
             report["completed_cycles"] = cycle_index
             report["incident_count"] += new_incidents
-            report["invariant_violations_found"] += diagnostics["truth"]["summary"]["warning_count"]
-            report["automatic_repairs_attempted"] += diagnostics["truth"]["summary"]["repaired_count"]
+            report["invariant_violations_found"] += cycle_summary["truth_warning_count_pre_reconcile"]
+            report["automatic_repairs_attempted"] += reconciliation["summary"]["repaired_count"]
             report["manual_stop_states_raised"] += cycle_summary["blocking_stop_states"]
             report["unreconciled_truth_mismatches"] = max(
                 report["unreconciled_truth_mismatches"],
-                diagnostics["truth"]["summary"]["warning_count"],
+                cycle_summary["truth_warning_count"],
             )
             report["duplicate_side_effects"] += cycle_summary["duplicate_side_effects"]
             applied_faults = list_fault_injections(connection, trust_run_id=trust_run_id)
@@ -675,7 +706,7 @@ def execute_trust_run(connection, project_paths, project_id, actor_id="agent_all
             report["faults_skipped"] = len([item for item in applied_faults if item["status"] == "skipped"])
             report["recent_cycles"] = (report["recent_cycles"] + [cycle_summary])[-8:]
             summary["latest_cycle"] = cycle_summary
-            summary["latest_reconciled_at"] = diagnostics["truth"].get("latest_reconciled_at")
+            summary["latest_reconciled_at"] = reconciliation.get("latest_reconciled_at") or diagnostics["truth"].get("latest_reconciled_at")
             _update_trust_run(
                 connection,
                 trust_run_id,

--- a/tests/test_trust_gate_api.py
+++ b/tests/test_trust_gate_api.py
@@ -1,0 +1,84 @@
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from maas.db import connect, project_paths
+from maas.services.autopilot import update_project_autopilot_policy
+from maas.services.bootstrap import bootstrap_project
+from maas.services.codex_mvp import fetch_system_diagnostics
+from maas.services.trust_gate import fetch_project_unattended_trust, update_project_unattended_mode
+from maas.services.trust_runs import execute_trust_run
+
+
+def _init_git_repo(root):
+    subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "MAAS Tests"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+class TrustGateApiTest(unittest.TestCase):
+    def test_trust_gate_reports_missing_evidence_and_disabled_autopilot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Trust Gate Missing Test", description="trust gate missing", project_type="custom")
+            _init_git_repo(tmpdir)
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                payload = fetch_project_unattended_trust(connection, paths, project_id)
+            finally:
+                connection.close()
+
+            self.assertFalse(payload["eligible"])
+            self.assertEqual(payload["status"], "unverified")
+            blocker_codes = {item["code"] for item in payload["blockers"]}
+            self.assertIn("trust_evidence_missing", blocker_codes)
+            self.assertIn("autopilot_disabled", blocker_codes)
+
+    def test_passing_trust_run_makes_project_eligible_and_arms_unattended_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Trust Gate Eligible Test", description="trust gate eligible", project_type="custom")
+            _init_git_repo(tmpdir)
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            git_snapshot = {
+                "is_git_repo": True,
+                "branch": "feature/trust-gate",
+                "default_branch": "main",
+                "dirty": False,
+                "gh_installed": True,
+            }
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                update_project_autopilot_policy(connection, paths, project_id, "agent_allocator", {"enabled": True})
+                with mock.patch("maas.services.delivery._git_repo_snapshot", return_value=git_snapshot):
+                    trust_run = execute_trust_run(connection, paths, project_id, cycle_limit=6, sleep_seconds=0)
+                gate = fetch_project_unattended_trust(connection, paths, project_id)
+                armed = update_project_unattended_mode(connection, paths, project_id, "agent_allocator", True)
+                diagnostics = fetch_system_diagnostics(connection, project_id, project_paths=paths)
+            finally:
+                connection.close()
+
+            self.assertEqual(trust_run["report"]["status"], "passed")
+            self.assertTrue(gate["eligible"])
+            self.assertEqual(gate["status"], "eligible")
+            self.assertEqual(armed["status"], "armed")
+            self.assertTrue(armed["unattended_mode_requested"])
+            self.assertIsNotNone(diagnostics["trust_gate"])
+            self.assertEqual(diagnostics["trust_gate"]["status"], "armed")
+
+    def test_update_unattended_mode_rejects_ineligible_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_project(tmpdir, name="Trust Gate Reject Test", description="trust gate reject", project_type="custom")
+            _init_git_repo(tmpdir)
+            paths = project_paths(tmpdir)
+            connection = connect(paths)
+            try:
+                project_id = connection.execute("SELECT project_id FROM projects LIMIT 1").fetchone()["project_id"]
+                with self.assertRaises(ValueError):
+                    update_project_unattended_mode(connection, paths, project_id, "agent_allocator", True)
+            finally:
+                connection.close()

--- a/web/src/lib/controlRoomApi.ts
+++ b/web/src/lib/controlRoomApi.ts
@@ -872,6 +872,13 @@ export async function updateProjectAutopilot(
   });
 }
 
+export async function updateProjectUnattendedMode(projectId: string, enabled: boolean) {
+  return postJson(`/api/projects/${projectId}/actions/update-unattended-mode`, {
+    actor_id: DEFAULT_ACTOR_ID,
+    enabled,
+  });
+}
+
 export function fetchEnvironmentDoctor(
   signal?: AbortSignal,
   onFallback?: () => void,
@@ -1548,6 +1555,7 @@ export function fetchCodexSystemDiagnostics(
         warnings: [],
       },
       trust_run: null,
+      trust_gate: null,
     },
     signal,
     onFallback,

--- a/web/src/pages/CodexSystemPage.tsx
+++ b/web/src/pages/CodexSystemPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { OperatorLoopPanel } from "../components/OperatorLoopPanel";
 import { CodexRunDetailCard } from "../components/CodexRunDetailCard";
-import { fetchActivity, fetchCodexRunDetail, fetchCodexSystemDiagnostics, fetchIncidentTimeline, fetchProviders, runControlOperatorAction, runSystemReconciliation, runSystemTrustSoak } from "../lib/controlRoomApi";
+import { fetchActivity, fetchCodexRunDetail, fetchCodexSystemDiagnostics, fetchIncidentTimeline, fetchProviders, runControlOperatorAction, runSystemReconciliation, runSystemTrustSoak, updateProjectUnattendedMode } from "../lib/controlRoomApi";
 import { fetchBoard } from "../lib/boardApi";
 import { boardCounts, formatTimestamp, openBoardTasks, resolvedBoardTasks } from "../lib/codexMvp";
 import type { OperatorLoopItem, OperatorWorkflowState } from "../lib/operatorLoop";
@@ -145,6 +145,25 @@ export function CodexSystemPage({
       );
     } catch (error) {
       setNotice(error instanceof Error ? error.message : "Trust soak failed.");
+    } finally {
+      setPendingActionKey(null);
+    }
+  }
+
+  async function handleUpdateUnattendedMode(enabled: boolean) {
+    const projectId = diagnostics?.trust_gate?.project_id ?? selectedProjectId;
+    if (!projectId) {
+      setNotice("Select a project before changing unattended mode.");
+      return;
+    }
+    setPendingActionKey(`system:unattended:${enabled ? "on" : "off"}`);
+    setNotice(null);
+    try {
+      const result = await updateProjectUnattendedMode(projectId, enabled);
+      await loadSystem();
+      setNotice(result.summary);
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : "Updating unattended mode failed.");
     } finally {
       setPendingActionKey(null);
     }
@@ -337,12 +356,80 @@ export function CodexSystemPage({
           <div className="codex-panel__header">
             <div>
               <span className="codex-kicker">Overnight trust</span>
-              <h2>Latest soak report</h2>
+              <h2>Trust gate and latest soak</h2>
             </div>
-            <span className="codex-chip">{runtimeDiagnostics?.trust_run?.report?.status ?? "idle"}</span>
+            <span className="codex-chip">{runtimeDiagnostics?.trust_gate?.status ?? runtimeDiagnostics?.trust_run?.report?.status ?? "idle"}</span>
           </div>
-          {runtimeDiagnostics?.trust_run ? (
+          {runtimeDiagnostics?.trust_gate ? (
             <div className="codex-run-list">
+              <div className="codex-run-item">
+                <div className="codex-run-item__meta">
+                  <strong>{runtimeDiagnostics.trust_gate.summary}</strong>
+                  <span>{runtimeDiagnostics.trust_gate.status.replaceAll("_", " ")}</span>
+                </div>
+                <span>{runtimeDiagnostics.trust_gate.detail}</span>
+                <span>
+                  {runtimeDiagnostics.trust_gate.truth_warning_count} live truth warnings · requires {runtimeDiagnostics.trust_gate.required_passed_cycles} cycle soak within {runtimeDiagnostics.trust_gate.max_trust_run_age_hours}h
+                </span>
+                <div className="codex-detail-actions">
+                  <button
+                    type="button"
+                    className="codex-button"
+                    onClick={() => void handleRunTrustSoak()}
+                    disabled={pendingActionKey === "system:trust-soak"}
+                  >
+                    {pendingActionKey === "system:trust-soak" ? "Running trust soak..." : "Run Trust Soak"}
+                  </button>
+                  <button
+                    type="button"
+                    className="codex-button codex-button--primary"
+                    onClick={() => void handleUpdateUnattendedMode(!runtimeDiagnostics.trust_gate?.unattended_mode_requested)}
+                    disabled={
+                      pendingActionKey === `system:unattended:${runtimeDiagnostics.trust_gate?.unattended_mode_requested ? "off" : "on"}` ||
+                      (!runtimeDiagnostics.trust_gate.unattended_mode_requested && !runtimeDiagnostics.trust_gate.eligible)
+                    }
+                  >
+                    {pendingActionKey === `system:unattended:${runtimeDiagnostics.trust_gate?.unattended_mode_requested ? "off" : "on"}`
+                      ? "Updating..."
+                      : runtimeDiagnostics.trust_gate.unattended_mode_requested
+                        ? "Disarm Unattended Mode"
+                        : runtimeDiagnostics.trust_gate.eligible
+                          ? "Arm Unattended Mode"
+                          : "Arm blocked until eligible"}
+                  </button>
+                </div>
+              </div>
+              {(runtimeDiagnostics.trust_gate.blockers ?? []).map((blocker) => (
+                <div key={`trust-blocker-${blocker.code}`} className="codex-run-item">
+                  <div className="codex-run-item__meta">
+                    <strong>{blocker.summary}</strong>
+                    <span>{blocker.severity}</span>
+                  </div>
+                  <span>{blocker.detail}</span>
+                  {blocker.operator_actions?.length ? (
+                    <div className="codex-detail-actions">
+                      {blocker.operator_actions.slice(0, 2).map((action) => (
+                        <button
+                          key={`${blocker.code}:${action.action}:${action.resource_id}`}
+                          type="button"
+                          className="codex-button"
+                          disabled={pendingActionKey === `${action.action}:${action.resource_id}`}
+                          onClick={() => void handleControlAction(action)}
+                        >
+                          {pendingActionKey === `${action.action}:${action.resource_id}` ? "Running..." : action.label}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+              {!runtimeDiagnostics.trust_gate.blockers?.length ? (
+                <div className="codex-empty-copy">No unattended trust blockers are active right now.</div>
+              ) : null}
+            </div>
+          ) : null}
+          {runtimeDiagnostics?.trust_run ? (
+            <div className="codex-run-list" style={{ marginTop: runtimeDiagnostics?.trust_gate ? "1rem" : undefined }}>
               <div className="codex-run-item">
                 <div className="codex-run-item__meta">
                   <strong>{runtimeDiagnostics.trust_run.summary?.project_name ?? "Trust run"}</strong>
@@ -366,9 +453,9 @@ export function CodexSystemPage({
                 </div>
               ))}
             </div>
-          ) : (
+          ) : !runtimeDiagnostics?.trust_gate ? (
             <div className="codex-empty-copy">No trust soak has been recorded yet for this project.</div>
-          )}
+          ) : null}
         </section>
 
         <section className="codex-panel">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2446,6 +2446,36 @@ export interface CodexSystemDiagnosticsResponse {
       replay?: Record<string, unknown>;
     }>;
   } | null;
+  trust_gate?: {
+    project_id: string;
+    status: "unverified" | "blocked" | "eligible" | "armed" | "armed_blocked";
+    eligible: boolean;
+    unattended_mode_requested: boolean;
+    summary: string;
+    detail: string;
+    checked_at: string;
+    required_passed_cycles: number;
+    max_trust_run_age_hours: number;
+    latest_trust_run_id?: string | null;
+    latest_trust_run_status?: string | null;
+    latest_trust_run_finished_at?: string | null;
+    truth_warning_count: number;
+    project_board?: {
+      enabled: boolean;
+      drift_count: number;
+      updated_count: number;
+      warnings?: Array<{
+        detail?: string | null;
+      }>;
+    };
+    blockers: Array<{
+      code: string;
+      summary: string;
+      detail: string;
+      severity: "info" | "warning" | "critical";
+      operator_actions?: ControlOperatorAction[];
+    }>;
+  } | null;
 }
 
 export interface CodexRunConsoleActivityItem {


### PR DESCRIPTION
Closes #133

## Summary
- add the unattended trust gate and explicit arm/disarm control for overnight local operation
- make trust soak reports decisive by reconciling each cycle and treating canonical safe stops separately from real unresolved truth drift
- surface the final trust gate in System diagnostics and the System page, with exact blockers and next actions

## Main changes
- `src/maas/services/trust_gate.py`
- `src/maas/services/trust_runs.py`
- `src/maas/services/codex_mvp.py`
- `src/maas/api.py`
- `web/src/pages/CodexSystemPage.tsx`
- `web/src/lib/controlRoomApi.ts`
- `web/src/types.ts`
- `tests/test_trust_gate_api.py`
- `docs/implementation/35-unattended-local-trust-final-closure-gate.md`

## Validation
- `PYTHONPATH=src .venv/bin/python -m compileall src/maas tests/test_trust_gate_api.py tests/test_trust_runs_api.py`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_trust_gate_api.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_trust_runs_api.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_codex_mvp_api.py -q -k "system_diagnostics_include_run_observability_and_suppression"`
- `cd web && npm run build`
- `git diff --check`

## Review
- attempted subagent review for backend and frontend scopes, but both review agents timed out in this environment
- completed a direct manual review and fixed the trust-run accounting issue where intentional review holds were incorrectly poisoning the final trust verdict before opening this PR